### PR TITLE
Add support for individual template descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ $ pulumi new
 
  1. Create a new directory under `templates/`, e.g. `templates/my-template-javascript`. By convention, hyphens are used to separate words and the language is included as a suffix.
  2. Add any text files for the template in the new directory.
+    - `.pulumi.template.yaml` can be included to specify a description for the template that will be used as a default value when replacing `${DESCRIPTION}` (see below).
 
 Travis publishes a tarball of each template directory under `templates/` in `master` to S3.
 

--- a/scripts/publish-template.sh
+++ b/scripts/publish-template.sh
@@ -3,14 +3,23 @@
 # s3://rel.pulumi.com/releases/templates.
 set -o nounset -o errexit -o pipefail
 
-# For now, all our templates have the same description.
-TEMPLATE_DESCRIPTION="A Pulumi project."
-
 ROOT=$(dirname $0)/..
 TEMPLATE_SOURCE_PATH="${ROOT}/templates/$1"
+TEMPLATE_MANIFEST_PATH="${TEMPLATE_SOURCE_PATH}/.pulumi.template.yaml"
 TEMPLATE_PACKAGE_NAME="$1.tar.gz"
 TEMPLATE_PACKAGE_DIR="$(mktemp -d)"
 TEMPLATE_PACKAGE_PATH="${TEMPLATE_PACKAGE_DIR}/${TEMPLATE_PACKAGE_NAME}"
+TEMPLATE_DESCRIPTION=""
+
+# If a manifest file exists, get the template description from it.
+if [ -f "$TEMPLATE_MANIFEST_PATH" ]; then
+    TEMPLATE_DESCRIPTION=$(sed -n "s/description: *\\(.*\\)/\\1/p" "$TEMPLATE_MANIFEST_PATH")
+fi
+
+# Otherwise, fallback to a default description.
+if [ -z "$TEMPLATE_DESCRIPTION" ]; then
+    TEMPLATE_DESCRIPTION="A Pulumi project."
+fi
 
 # Tar up the template
 tar -czf ${TEMPLATE_PACKAGE_PATH} -C ${TEMPLATE_SOURCE_PATH} .

--- a/templates/javascript/.pulumi.template.yaml
+++ b/templates/javascript/.pulumi.template.yaml
@@ -1,0 +1,1 @@
+description: A Pulumi project.

--- a/templates/python/.pulumi.template.yaml
+++ b/templates/python/.pulumi.template.yaml
@@ -1,0 +1,1 @@
+description: A Pulumi project.

--- a/templates/typescript/.pulumi.template.yaml
+++ b/templates/typescript/.pulumi.template.yaml
@@ -1,0 +1,1 @@
+description: A Pulumi project.


### PR DESCRIPTION
Adds a manifest file to each template with its own description, and use the description in the manifest as the `pulumi-template-description` metadata when uploading to S3.