### PR TITLE
Add a template manifest for hello-aws-javascript

### DIFF
--- a/templates/hello-aws-javascript/.pulumi.template.yaml
+++ b/templates/hello-aws-javascript/.pulumi.template.yaml
@@ -1,0 +1,3 @@
+installdependencies: true
+config:
+  aws:region: us-west-2


### PR DESCRIPTION
The manifest indicates that deps should be installed and adds a default config value for `aws:region`.

@lukehoban, I assume we want to use `us-west-2` as the default value for `aws:region`. LMK if that's not the case.