### PR TITLE
Remove /stage from index.html

### DIFF
--- a/templates/hello-aws-javascript/www/index.html
+++ b/templates/hello-aws-javascript/www/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Hello Pulumi</title>
-    <link rel="shortcut icon" href="/stage/favicon.png" type="image/png">
+    <link rel="shortcut icon" href="favicon.png" type="image/png">
 </head>
 <body>
     <p>Hello, world!</p>
@@ -11,7 +11,7 @@
     <p>Served from: <span id="source"></span></p>
 </body>
 <script>
-    fetch("/stage/source").then(response => response.json()).then(json => {
+    fetch("source").then(response => response.json()).then(json => {
         document.getElementById("source").innerText = json.name;
     });
 </script>


### PR DESCRIPTION
I used this pattern when I created url shortener, but it was probably never necessary. Verified it works with out the `/stage` after a private beta user pointed it out.