### PR TITLE
Cleanup README based on CLI changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Pulumi Templates
 
-This repo contains the templates for `pulumi new <template>`, which makes it easy to quickly automatically create the handful of needed files to get started building an empty Pulumi project.
+This repo contains the templates for `pulumi new [template]`, which make it easy to quickly get started building new Pulumi projects.
 
 ## Using a template
 
@@ -11,10 +11,10 @@ You can use the CLI to create a new project from a template:
 ```
 $ mkdir myproj
 $ cd myproj
-$ pulumi new <template>
+$ pulumi new [template]
 ```
 
-If `<template>` isn't specified, the CLI will offer a list of available templates to choose from:
+If `[template]` isn't specified, the CLI will offer a list of available templates to choose from:
 
 ```
 $ pulumi new
@@ -26,7 +26,8 @@ $ pulumi new
 ## Adding a new template
 
  1. Create a new directory under `templates/`, e.g. `templates/my-template-javascript`. By convention, hyphens are used to separate words and the language is included as a suffix.
- 2. Add any text files for the template in the new directory.
+
+ 2. Add template files in the new directory.
 
 Travis publishes a tarball of each template directory under `templates/` in `master` to S3.
 
@@ -34,8 +35,7 @@ Once the template has been published, it will be included in the JSON list of te
 
 ## Text replacement
 
-The CLI assumes all template files are text files. The following special strings can be included in any template file; these will be replaced by the CLI when laying down the template files.
+The following special strings can be included in any template file; these will be replaced by the CLI when laying down the template files.
 
- - `${PROJECT}` - Replaced with the name of the current directory by default (invalid characters are excluded, falling back to `project`). Alternatively, it can be specified explicitly using the `--name` flag.
-
- - `${DESCRIPTION}` - Replaced with the template description by default (falling back to `A Pulumi project.` if not available). Alternatively, it can be specified explicitly using the `--description` flag.
+ - `${PROJECT}` - The name of the project.
+ - `${DESCRIPTION}` - The description of the project.


### PR DESCRIPTION
Remove unnecessary details about the CLI that are no longer true:
- Binary files are now supported
- The CLI prompts for the project name and description