### PR TITLE
Allow dep constraints to float

### DIFF
--- a/templates/aws-go/Gopkg.toml
+++ b/templates/aws-go/Gopkg.toml
@@ -1,9 +1,9 @@
 [[constraint]]
-  version = "v0.14.0"
+  version = ">=0.14.0"
   name = "github.com/pulumi/pulumi"
 
 [[constraint]]
-  version = "v0.14.0"
+  version = ">=0.14.0"
   name = "github.com/pulumi/pulumi-aws"
 
 [prune]

--- a/templates/go/Gopkg.toml
+++ b/templates/go/Gopkg.toml
@@ -1,5 +1,5 @@
 [[constraint]]
-  branch = "v0.14.0"
+  version = ">=0.14.0"
   name = "github.com/pulumi/pulumi"
 
 [prune]


### PR DESCRIPTION
We use the "latest" tag in our templates for node and we use >=0.14.0
for our pip constraints, so these will both float to newer released
versions (even across minor versions). Change the dep constraint to
have the same semantics (it was implicitly a ^ style constraint, so
it would not float across minor versions)