### PR TITLE
Add template section to Pulumi.yaml files

### DIFF
--- a/templates/aws-go/Pulumi.yaml
+++ b/templates/aws-go/Pulumi.yaml
@@ -1,3 +1,9 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
 runtime: go
+template:
+  description: A minimal AWS Go program
+  config:
+    aws:region:
+      description: The AWS region to deploy into
+      default: us-east-1

--- a/templates/aws-javascript/Pulumi.yaml
+++ b/templates/aws-javascript/Pulumi.yaml
@@ -1,3 +1,9 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
 runtime: nodejs
+template:
+  description: A minimal AWS JavaScript program
+  config:
+    aws:region:
+      description: The AWS region to deploy into
+      default: us-east-1

--- a/templates/aws-python/Pulumi.yaml
+++ b/templates/aws-python/Pulumi.yaml
@@ -1,3 +1,9 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
 runtime: python
+template:
+  description: A minimal AWS Python program
+  config:
+    aws:region:
+      description: The AWS region to deploy into
+      default: us-east-1

--- a/templates/aws-typescript/Pulumi.yaml
+++ b/templates/aws-typescript/Pulumi.yaml
@@ -1,3 +1,9 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
 runtime: nodejs
+template:
+  description: A minimal AWS TypeScript program
+  config:
+    aws:region:
+      description: The AWS region to deploy into
+      default: us-east-1

--- a/templates/go/Pulumi.yaml
+++ b/templates/go/Pulumi.yaml
@@ -1,3 +1,5 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
 runtime: go
+template:
+  description: A minimal Go program

--- a/templates/hello-aws-javascript/Pulumi.yaml
+++ b/templates/hello-aws-javascript/Pulumi.yaml
@@ -1,3 +1,9 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
 runtime: nodejs
+template:
+  description: A simple AWS serverless JavaScript program
+  config:
+    aws:region:
+      description: The AWS region to deploy into
+      default: us-east-1

--- a/templates/javascript/Pulumi.yaml
+++ b/templates/javascript/Pulumi.yaml
@@ -1,3 +1,5 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
 runtime: nodejs
+template:
+  description: A minimal JavaScript program

--- a/templates/python/Pulumi.yaml
+++ b/templates/python/Pulumi.yaml
@@ -1,3 +1,5 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
 runtime: python
+template:
+  description: A minimal Python program

--- a/templates/typescript/Pulumi.yaml
+++ b/templates/typescript/Pulumi.yaml
@@ -1,3 +1,5 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
 runtime: nodejs
+template:
+  description: A minimal TypeScript program


### PR DESCRIPTION
This adds a top-level `template` key to each template's `Pulumi.yaml` (what we'd previously talked about calling `quickstart`).

An optional `quickstart` key under `template` is supported to specify text to print to `stdout` after project creation (though, none of the templates here currently use it).

Note that the existing `.pulumi.template.yaml` files will remain for now for versions of the CLI still in use (until we can phase it out). The updated template implementation ignores/skips this file if it is present.