### PR TITLE
Remove the .pulumi folder from .gitignore in templates

### DIFF
--- a/aws-javascript/.gitignore
+++ b/aws-javascript/.gitignore
@@ -1,2 +1,1 @@
 /node_modules/
-/.pulumi/

--- a/aws-python/.gitignore
+++ b/aws-python/.gitignore
@@ -1,2 +1,1 @@
-/.pulumi/
 *.pyc

--- a/aws-typescript/.gitignore
+++ b/aws-typescript/.gitignore
@@ -1,3 +1,2 @@
 /bin/
 /node_modules/
-/.pulumi/

--- a/javascript/.gitignore
+++ b/javascript/.gitignore
@@ -1,2 +1,1 @@
 /node_modules/
-/.pulumi/

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,2 +1,1 @@
-/.pulumi/
 *.pyc

--- a/typescript/.gitignore
+++ b/typescript/.gitignore
@@ -1,3 +1,2 @@
 /bin/
 /node_modules/
-/.pulumi/


### PR DESCRIPTION
This is a holdover from a long while back where Pulumi would keep
certain bookeeping data in a directory called .pulumi at the root of
your application.

We no longer do this, so we can remove these directives.