### PR TITLE
Add minimal Kubernetes template

### DIFF
--- a/kubernetes-typescript/.gitignore
+++ b/kubernetes-typescript/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/kubernetes-typescript/Pulumi.yaml
+++ b/kubernetes-typescript/Pulumi.yaml
@@ -1,0 +1,9 @@
+name: ${PROJECT}
+description: ${DESCRIPTION}
+runtime: nodejs
+template:
+  description: A minimal Kubernetes TypeScript program
+  config:
+    kubeapp:image:
+      description: The image for the container to run
+      default: nginx

--- a/kubernetes-typescript/index.ts
+++ b/kubernetes-typescript/index.ts
@@ -1,0 +1,20 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+
+const name = pulumi.getProject();
+
+const config = new pulumi.Config("kubeapp");
+const image = config.require("image");
+const replicas = config.getNumber("replicas") || 1;
+
+const appLabels = { app: name };
+const deployment = new k8s.apps.v1beta1.Deployment(name, {
+    spec: {
+        selector: { matchLabels: appLabels },
+        replicas: replicas,
+        template: {
+            metadata: { labels: appLabels },
+            spec: { containers: [{ name: name, image: image }] }
+        }
+    }
+});

--- a/kubernetes-typescript/package.json
+++ b/kubernetes-typescript/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "${PROJECT}",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/kubernetes-typescript/tsconfig.json
+++ b/kubernetes-typescript/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
I removed the `// Parameters` comments, kept `name` and `image` `const`s, and moved `replicas` inline.

~~Note: Matt and I are still playing around with whether we want to keep the `tsconfig.json` in the templates or not. If we decide we don't want it, I'll remove it in a follow-up PR.~~ We're going to keep the `tsconfig.json` for now.

---

If you want to try it out before this PR is merged:

```bash
pulumi new https://github.com/pulumi/templates/tree/justin/k8s/kubernetes-typescript
```

After it's merged it will be:

```bash
pulumi new kubernetes-typescript
```