### PR TITLE
Stop replacing the project name in package.json

### DIFF
--- a/aws-javascript/package.json
+++ b/aws-javascript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "${PROJECT}",
+    "name": "aws-javascript",
     "main": "index.js",
     "dependencies": {
         "@pulumi/pulumi": "latest",

--- a/aws-typescript/package.json
+++ b/aws-typescript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "${PROJECT}",
+    "name": "aws-typescript",
     "devDependencies": {
         "@types/node": "latest"
     },

--- a/azure-javascript/package.json
+++ b/azure-javascript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "${PROJECT}",
+    "name": "azure-javascript",
     "main": "index.js",
     "dependencies": {
         "@pulumi/pulumi": "latest",

--- a/azure-typescript/package.json
+++ b/azure-typescript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "${PROJECT}",
+    "name": "azure-typescript",
     "devDependencies": {
         "@types/node": "latest"
     },

--- a/gcp-javascript/package.json
+++ b/gcp-javascript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "${PROJECT}",
+    "name": "gcp-javascript",
     "main": "index.js",
     "dependencies": {
         "@pulumi/pulumi": "latest",

--- a/gcp-typescript/package.json
+++ b/gcp-typescript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "${PROJECT}",
+    "name": "gcp-typescript",
     "devDependencies": {
         "@types/node": "latest"
     },

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "${PROJECT}",
+    "name": "javascript",
     "main": "index.js",
     "dependencies": {
         "@pulumi/pulumi": "latest"

--- a/kubernetes-javascript/package.json
+++ b/kubernetes-javascript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "${PROJECT}",
+    "name": "kubernetes-javascript",
     "main": "index.js",
     "dependencies": {
         "@pulumi/pulumi": "latest",

--- a/kubernetes-typescript/package.json
+++ b/kubernetes-typescript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "${PROJECT}",
+    "name": "kubernetes-typescript",
     "devDependencies": {
         "@types/node": "latest"
     },

--- a/openstack-javascript/package.json
+++ b/openstack-javascript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "${PROJECT}",
+    "name": "openstack-javascript",
     "main": "index.js",
     "dependencies": {
         "@pulumi/pulumi": "latest",

--- a/openstack-typescript/package.json
+++ b/openstack-typescript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "${PROJECT}",
+    "name": "openstack-typescript",
     "devDependencies": {
         "@types/node": "latest"
     },

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "${PROJECT}",
+    "name": "typescript",
     "devDependencies": {
         "@types/node": "latest"
     },


### PR DESCRIPTION
We've moved away from using the ${PROJECT} and ${DESCRIPTION} replacement strings in Pulumi.yaml and package.json, primarily so that `pulumi new <url>` and `pulumi up <url>` can be used with examples that don't use these replacement strings (allowing such examples to be usable/buildable on their own without any templating).

Instead of doing a search/replace of these replacement strings, v0.15.2 of the CLI now overwrites any existing `name` and `description` values in Pulumi.yaml and saves the file, and doesn't do anything to update/save the `name` specified in package.json. The replacement strings can be used, but they are no longer required with this version of the CLI.

However, v0.15.0 of the CLI only does a search/replace, so we must keep ${PROJECT} and ${DESCRIPTION} in Pulumi.yaml in the templates in pulumi/templates as long as we want v0.15.0 to continue working with our templates. (Earlier versions of the CLI before v0.15.0 download templates from S3, and therefore aren't affected by any changes we make to templates in this repo (unless we force updates to the templates in S3)).

But there's no need to keep ${PROJECT} in package.json. Since we decided we're no longer going to change the project name in package.json, we can simply remove the replacement string there.

This works around an issue where we currently allow project names that can have characters (such as `/`) that NPM doesn't allow for the `name` in package.json.

Fixes https://github.com/pulumi/pulumi/issues/1979