### PR TITLE
Export the Kubernetes deployment name

### DIFF
--- a/kubernetes-javascript/index.js
+++ b/kubernetes-javascript/index.js
@@ -12,3 +12,4 @@ const deployment = new k8s.apps.v1.Deployment("nginx", {
         }
     }
 });
+exports.name = deployment.metadata.apply(m => m.name);

--- a/kubernetes-typescript/index.ts
+++ b/kubernetes-typescript/index.ts
@@ -11,3 +11,4 @@ const deployment = new k8s.apps.v1.Deployment("nginx", {
         }
     }
 });
+export const name = deployment.metadata.apply(m => m.name);


### PR DESCRIPTION
This change exports the resulting Kubernetes deployment name
from the templates, making it easier to tool. E.g.

    $ pulumi new kubernetes-typescript
    ...
    $ kubectl get deployment $(pulumi stack output name)