### PR TITLE
Don't use "dev" tags in templates

### DIFF
--- a/hello-aws-javascript/package.json
+++ b/hello-aws-javascript/package.json
@@ -2,7 +2,7 @@
     "name": "hello-aws-javascript",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "dev",
-        "@pulumi/aws": "dev"
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest"
     }
 }


### PR DESCRIPTION
Having `pulumi new` generate a project that just installs daily builds
is likely to lead to a bad experience.

Move to "latest" like the other templates, which picks up the most
recently released version.