### PR TITLE
Add missing function call to `aws-go`

### DIFF
--- a/aws-go/main.go
+++ b/aws-go/main.go
@@ -14,7 +14,7 @@ func main() {
 		}
 
 		// Export the DNS name of the bucket
-		ctx.Export("bucketName", bucket.BucketDomainName)
+		ctx.Export("bucketName", bucket.BucketDomainName())
 		return nil
 	})
 }


### PR DESCRIPTION
`BucketDomainName` is a function, so it should be called 👌 

Before:
```
▲ (matheus-vm) infra [add/pulumi] pulumi preview
Previewing update (redacted):

     Type                 Name                   Plan       Info
 +   pulumi:pulumi:Stack  redacted  create     1 error; 2 messages
 +   └─ aws:s3:Bucket     my-bucket              create

Diagnostics:
  pulumi:pulumi:Stack (redacted):
    error: program failed: 1 error occurred:
        * marshaling outputs: awaiting input property bucketName: unrecognized input property type: 0xa00d00 (func() *pulumi.StringOutput)

    error: an unhandled error occurred: program exited with non-zero exit code: 1

Permalink: redacted
error: an error occurred while advancing the preview
▲ (matheus-vm) infra [add/pulumi]
```

After:
```
▲ (matheus-vm) infra [add/pulumi] pulumi preview
Previewing update (redacted):

     Type                 Name                   Plan
 +   pulumi:pulumi:Stack  redacted  create
 +   └─ aws:s3:Bucket     my-bucket              create

Resources:
    + 2 to create

Permalink: redacted
▲ (matheus-vm) infra [add/pulumi]
```
