### PR TITLE
Export the ID of the bucket instead of the domain name

### DIFF
--- a/aws-go/main.go
+++ b/aws-go/main.go
@@ -14,7 +14,7 @@ func main() {
 		}
 
 		// Export the DNS name of the bucket
-		ctx.Export("bucketName", bucket.BucketDomainName())
+		ctx.Export("bucketName", bucket.ID())
 		return nil
 	})
 }

--- a/aws-go/main.go
+++ b/aws-go/main.go
@@ -13,7 +13,7 @@ func main() {
 			return err
 		}
 
-		// Export the DNS name of the bucket
+		// Export the name of the bucket
 		ctx.Export("bucketName", bucket.ID())
 		return nil
 	})

--- a/aws-javascript/index.js
+++ b/aws-javascript/index.js
@@ -5,5 +5,5 @@ const aws = require("@pulumi/aws");
 // Create an AWS resource (S3 Bucket)
 const bucket = new aws.s3.Bucket("my-bucket");
 
-// Export the DNS name of the bucket
+// Export the name of the bucket
 exports.bucketName = bucket.id;

--- a/aws-javascript/index.js
+++ b/aws-javascript/index.js
@@ -6,4 +6,4 @@ const aws = require("@pulumi/aws");
 const bucket = new aws.s3.Bucket("my-bucket");
 
 // Export the DNS name of the bucket
-exports.bucketName = bucket.bucketDomainName;
+exports.bucketName = bucket.id;

--- a/aws-python/__main__.py
+++ b/aws-python/__main__.py
@@ -4,5 +4,5 @@ from pulumi_aws import s3
 # Create an AWS resource (S3 Bucket)
 bucket = s3.Bucket('my-bucket')
 
-# Export the DNS name of the bucket
+# Export the name of the bucket
 pulumi.export('bucket_name',  bucket.id)

--- a/aws-python/__main__.py
+++ b/aws-python/__main__.py
@@ -5,4 +5,4 @@ from pulumi_aws import s3
 bucket = s3.Bucket('my-bucket')
 
 # Export the DNS name of the bucket
-pulumi.export('bucket_name',  bucket.bucket_domain_name)
+pulumi.export('bucket_name',  bucket.id)

--- a/aws-typescript/index.ts
+++ b/aws-typescript/index.ts
@@ -4,5 +4,5 @@ import * as aws from "@pulumi/aws";
 // Create an AWS resource (S3 Bucket)
 const bucket = new aws.s3.Bucket("my-bucket");
 
-// Export the DNS name of the bucket
+// Export the name of the bucket
 export const bucketName = bucket.id;

--- a/aws-typescript/index.ts
+++ b/aws-typescript/index.ts
@@ -5,4 +5,4 @@ import * as aws from "@pulumi/aws";
 const bucket = new aws.s3.Bucket("my-bucket");
 
 // Export the DNS name of the bucket
-export const bucketName = bucket.bucketDomainName;
+export const bucketName = bucket.id;


### PR DESCRIPTION
The domain name is almost never needed.

The name of the bucket which is used for `s3://` paths (as well as in the domain name) is the more generally useful and is available as the `id` property.