### PR TITLE
Update tsconfig.json

### DIFF
--- a/linode-typescript/tsconfig.json
+++ b/linode-typescript/tsconfig.json
@@ -13,7 +13,7 @@
         "noFallthroughCasesInSwitch": true,
         "noImplicitAny": true,
         "noImplicitReturns": true,
-        "forceConsistentCasingInFileLabels": true,
+        "forceConsistentCasingInFileNames": true,
         "strictNullChecks": true
     },
     "files": [


### PR DESCRIPTION
`forceConsistentCasingInFileLabels` isn't a valid [Typescript compiler option](https://www.typescriptlang.org/docs/handbook/compiler-options.html), as indicated by the following error returned when attempting `pulumi up`:
```
TSError: ⨯ Unable to compile TypeScript:
error TS5023: Unknown compiler option 'forceConsistentCasingInFileLabels'.
```

Replacing this option with `forceConsistentCasingInFileNames` resolves this issue (this option is used in analogous template files for other providers).