### PR TITLE
Pin NPM dependencies to `0.x.y`

### DIFF
--- a/aws-javascript/package.json
+++ b/aws-javascript/package.json
@@ -2,8 +2,8 @@
     "name": "aws-javascript",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/aws": "latest",
-        "@pulumi/awsx": "latest"
+        "@pulumi/pulumi": "^0.17.28",
+        "@pulumi/aws": "^0.18.27",
+        "@pulumi/awsx": "^0.18.8"
     }
 }

--- a/aws-typescript/package.json
+++ b/aws-typescript/package.json
@@ -4,8 +4,8 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/aws": "latest",
-        "@pulumi/awsx": "latest"
+        "@pulumi/pulumi": "^0.17.28",
+        "@pulumi/aws": "^0.18.27",
+        "@pulumi/awsx": "^0.18.8"
     }
 }

--- a/azure-javascript/package.json
+++ b/azure-javascript/package.json
@@ -2,7 +2,7 @@
     "name": "azure-javascript",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/azure": "latest"
+        "@pulumi/pulumi": "^0.17.28",
+        "@pulumi/azure": "^0.19.5"
     }
 }

--- a/azure-typescript/package.json
+++ b/azure-typescript/package.json
@@ -4,7 +4,7 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/azure": "latest"
+        "@pulumi/pulumi": "^0.17.28",
+        "@pulumi/azure": "^0.19.5"
     }
 }

--- a/digitalocean-javascript/package.json
+++ b/digitalocean-javascript/package.json
@@ -2,7 +2,7 @@
     "name": "digitalocean-javascript",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/digitalocean": "latest"
+        "@pulumi/pulumi": "^0.17.28",
+        "@pulumi/digitalocean": "^0.18.10"
     }
 }

--- a/digitalocean-typescript/package.json
+++ b/digitalocean-typescript/package.json
@@ -4,7 +4,7 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/digitalocean": "latest"
+        "@pulumi/pulumi": "^0.17.28",
+        "@pulumi/digitalocean": "^0.18.10"
     }
 }

--- a/gcp-javascript/package.json
+++ b/gcp-javascript/package.json
@@ -2,7 +2,7 @@
     "name": "gcp-javascript",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/gcp": "latest"
+        "@pulumi/pulumi": "^0.17.28",
+        "@pulumi/gcp": "^0.18.16"
     }
 }

--- a/gcp-typescript/package.json
+++ b/gcp-typescript/package.json
@@ -4,7 +4,7 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/gcp": "latest"
+        "@pulumi/pulumi": "^0.17.28",
+        "@pulumi/gcp": "^0.18.16"
     }
 }

--- a/hello-aws-javascript/package.json
+++ b/hello-aws-javascript/package.json
@@ -2,8 +2,8 @@
     "name": "hello-aws-javascript",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/aws": "latest",
-        "@pulumi/awsx": "latest"
+        "@pulumi/pulumi": "^0.17.28",
+        "@pulumi/aws": "^0.18.27",
+        "@pulumi/awsx": "^0.18.8"
     }
 }

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -2,6 +2,6 @@
     "name": "javascript",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "latest"
+        "@pulumi/pulumi": "^0.17.28"
     }
 }

--- a/kubernetes-javascript/package.json
+++ b/kubernetes-javascript/package.json
@@ -2,7 +2,7 @@
     "name": "kubernetes-javascript",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/kubernetes": "latest"
+        "@pulumi/pulumi": "^0.17.28",
+        "@pulumi/kubernetes": "^0.25.6"
     }
 }

--- a/kubernetes-typescript/package.json
+++ b/kubernetes-typescript/package.json
@@ -4,7 +4,7 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/kubernetes": "latest"
+        "@pulumi/pulumi": "^0.17.28",
+        "@pulumi/kubernetes": "^0.25.6"
     }
 }

--- a/linode-javascript/package.json
+++ b/linode-javascript/package.json
@@ -2,7 +2,7 @@
     "name": "linode-javascript",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/linode": "latest"
+        "@pulumi/pulumi": "^0.17.28",
+        "@pulumi/linode": "^0.18.8"
     }
 }

--- a/linode-typescript/package.json
+++ b/linode-typescript/package.json
@@ -4,7 +4,7 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/linode": "latest"
+        "@pulumi/pulumi": "^0.17.28",
+        "@pulumi/linode": "^0.18.8"
     }
 }

--- a/openstack-javascript/package.json
+++ b/openstack-javascript/package.json
@@ -2,7 +2,7 @@
     "name": "openstack-javascript",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/openstack": "latest"
+        "@pulumi/pulumi": "^0.17.28",
+        "@pulumi/openstack": "^0.17.7"
     }
 }

--- a/openstack-typescript/package.json
+++ b/openstack-typescript/package.json
@@ -4,7 +4,7 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/openstack": "latest"
+        "@pulumi/pulumi": "^0.17.28",
+        "@pulumi/openstack": "^0.17.7"
     }
 }

--- a/packet-javascript/package.json
+++ b/packet-javascript/package.json
@@ -2,7 +2,7 @@
     "name": "packet-javascript",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/packet": "latest"
+        "@pulumi/pulumi": "^0.17.28",
+        "@pulumi/packet": "^0.4.9"
     }
 }

--- a/packet-typescript/package.json
+++ b/packet-typescript/package.json
@@ -4,7 +4,7 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/packet": "latest"
+        "@pulumi/pulumi": "^0.17.28",
+        "@pulumi/packet": "^0.4.9"
     }
 }

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -4,6 +4,6 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "latest"
+        "@pulumi/pulumi": "^0.17.28"
     }
 }


### PR DESCRIPTION
Until we have finalized the preparations for `1.0.0-beta.1` across providers, we need to ensure that we fix this so that users don't get a mix of Pulumi package version.