### PR TITLE
Blank root namespaces for VB

### DIFF
--- a/alicloud-visualbasic/${PROJECT}.vbproj
+++ b/alicloud-visualbasic/${PROJECT}.vbproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <RootNamespace></RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/aws-visualbasic/${PROJECT}.vbproj
+++ b/aws-visualbasic/${PROJECT}.vbproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <RootNamespace></RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/azure-visualbasic/${PROJECT}.vbproj
+++ b/azure-visualbasic/${PROJECT}.vbproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <RootNamespace></RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/gcp-visualbasic/${PROJECT}.vbproj
+++ b/gcp-visualbasic/${PROJECT}.vbproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <RootNamespace></RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/visualbasic/${PROJECT}.vbproj
+++ b/visualbasic/${PROJECT}.vbproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <RootNamespace></RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Visual Basic assumes the project name to be the root namespace by default. With dynamic project names, it can be set to something like `test-name` which is not a valid namespace.
This leads to a broken project ([example](https://travis-ci.com/pulumi/templates/builds/148539544#L1481)).
Blanking out the root namespace explicitly should help avoid the situation. I tested and the project compiles and runs.