### PR TITLE
bump sdk version for go templates

### DIFF
--- a/alicloud-go/go.mod
+++ b/alicloud-go/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	github.com/pulumi/pulumi-alicloud/sdk/v2 v2.16.0
-	github.com/pulumi/pulumi/sdk/v2 v2.9.2
+	github.com/pulumi/pulumi/sdk/v2 v2.18.2
 )

--- a/aws-go/go.mod
+++ b/aws-go/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v3 v3.2.1
-	github.com/pulumi/pulumi/sdk/v2 v2.9.2
+	github.com/pulumi/pulumi/sdk/v2 v2.18.2
 )

--- a/azure-go/go.mod
+++ b/azure-go/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	github.com/pulumi/pulumi-azure/sdk/v3 v3.20.0
-	github.com/pulumi/pulumi/sdk/v2 v2.9.2
+	github.com/pulumi/pulumi/sdk/v2 v2.18.2
 )

--- a/azure-nextgen-go/go.mod
+++ b/azure-nextgen-go/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	github.com/pulumi/pulumi-azure-nextgen/sdk v0.3.1
-	github.com/pulumi/pulumi/sdk/v2 v2.16.0
+	github.com/pulumi/pulumi/sdk/v2 v2.18.2
 )

--- a/digitalocean-go/go.mod
+++ b/digitalocean-go/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	github.com/pulumi/pulumi-digitalocean/sdk/v3 v3.0.0
-	github.com/pulumi/pulumi/sdk/v2 v2.9.2
+	github.com/pulumi/pulumi/sdk/v2 v2.18.2
 )

--- a/gcp-go/go.mod
+++ b/gcp-go/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	github.com/pulumi/pulumi-gcp/sdk/v4 v4.0.0
-	github.com/pulumi/pulumi/sdk/v2 v2.9.2
+	github.com/pulumi/pulumi/sdk/v2 v2.18.2
 )

--- a/go/go.mod
+++ b/go/go.mod
@@ -2,4 +2,4 @@ module ${PROJECT}
 
 go 1.14
 
-require github.com/pulumi/pulumi/sdk/v2 v2.9.2
+require github.com/pulumi/pulumi/sdk/v2 v2.18.2

--- a/kubernetes-go/go.mod
+++ b/kubernetes-go/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	github.com/pulumi/pulumi-kubernetes/sdk/v2 v2.5.1
-	github.com/pulumi/pulumi/sdk/v2 v2.9.2
+	github.com/pulumi/pulumi/sdk/v2 v2.18.2
 )

--- a/linode-go/go.mod
+++ b/linode-go/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	github.com/pulumi/pulumi-linode/sdk/v2 v2.5.0
-	github.com/pulumi/pulumi/sdk/v2 v2.9.2
+	github.com/pulumi/pulumi/sdk/v2 v2.18.2
 )

--- a/openstack-go/go.mod
+++ b/openstack-go/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	github.com/pulumi/pulumi-openstack/sdk/v2 v2.6.0
-	github.com/pulumi/pulumi/sdk/v2 v2.9.2
+	github.com/pulumi/pulumi/sdk/v2 v2.18.2
 )

--- a/packet-go/go.mod
+++ b/packet-go/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	github.com/pulumi/pulumi-packet/sdk/v3 v3.1.0
-	github.com/pulumi/pulumi/sdk/v2 v2.9.2
+	github.com/pulumi/pulumi/sdk/v2 v2.18.2
 )


### PR DESCRIPTION
just do the simple thing to make sure new users are getting the latest build (for now)
broader issue tracked here: https://github.com/pulumi/templates/issues/114