### PR TITLE
Run the templates from the PR source if exists

### DIFF
--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -76,6 +76,8 @@ jobs:
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
+      - name: Set the Template URL using local repo path
+        run: echo "PULUMI_TEMPLATE_LOCATION=${{ github.workspace}}" >> $GITHUB_ENV
       - name: Get dependencies non-windows
         run: make ensure
       - name: Run tests

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -47,6 +47,15 @@ func TestTemplates(t *testing.T) {
 		fmt.Println("Defaulting GOOGLE_ZONE to 'us-central1-a'.  You can override using the GOOGLE_ZONE variable")
 	}
 
+	// by default, we want to test the normal template url path
+	// if we have a specific template location set then we should
+	// use that in our tests
+	templateUrl := ""
+	specificTemplate := os.Getenv("PULUMI_TEMPLATE_LOCATION")
+	if specificTemplate != "" {
+		templateUrl = specificTemplate
+	}
+
 	base := integration.ProgramTestOptions{
 		ExpectRefreshChanges:   true,
 		Quick:                  true,
@@ -56,7 +65,7 @@ func TestTemplates(t *testing.T) {
 	}
 
 	// Retrieve the template repo.
-	repo, err := workspace.RetrieveTemplates("", false /*offline*/, workspace.TemplateKindPulumiProject)
+	repo, err := workspace.RetrieveTemplates(templateUrl, false /*offline*/, workspace.TemplateKindPulumiProject)
 	assert.NoError(t, err)
 	defer assert.NoError(t, repo.Delete())
 


### PR DESCRIPTION
If we are changing the templates in a PR, then we should pass
the ref to the template checkout otherwise we are running tests
from the main line not the PR itself