### PR TITLE
Remove deprecated 'latest' from Azure native templates

### DIFF
--- a/azure-csharp/MyStack.cs
+++ b/azure-csharp/MyStack.cs
@@ -1,8 +1,8 @@
 using System.Threading.Tasks;
 using Pulumi;
-using Pulumi.AzureNative.Resources.Latest;
-using Pulumi.AzureNative.Storage.Latest;
-using Pulumi.AzureNative.Storage.Latest.Inputs;
+using Pulumi.AzureNative.Resources;
+using Pulumi.AzureNative.Storage;
+using Pulumi.AzureNative.Storage.Inputs;
 
 class MyStack : Stack
 {

--- a/azure-fsharp/Program.fs
+++ b/azure-fsharp/Program.fs
@@ -1,9 +1,9 @@
 ﻿module Program
 
 open Pulumi.FSharp
-open Pulumi.AzureNative.Resources.Latest
-open Pulumi.AzureNative.Storage.Latest
-open Pulumi.AzureNative.Storage.Latest.Inputs
+open Pulumi.AzureNative.Resources
+open Pulumi.AzureNative.Storage
+open Pulumi.AzureNative.Storage.Inputs
 
 // Helper function to retrieve the primary key of a storage account
 let getStorageAccountPrimaryKey(resourceGroupName: string, accountName: string): Async<string> = async {
@@ -21,17 +21,17 @@ let infra () =
 
     // Create an Azure Storage Account
     let storageAccount =
-        StorageAccount("sa", 
+        StorageAccount("sa",
             StorageAccountArgs
                 (ResourceGroupName = io resourceGroup.Name,
                  Sku = input (SkuArgs(Name = inputUnion2Of2 SkuName.Standard_LRS)),
                  Kind = inputUnion2Of2 Kind.StorageV2))
-        
+
     // Get the primary key
     let primaryKey =
         Outputs.pair resourceGroup.Name storageAccount.Name
         |> Outputs.applyAsync getStorageAccountPrimaryKey
-    
+
     // Export the primary key for the storage account
     dict [("connectionString", primaryKey :> obj)]
 

--- a/azure-python/__main__.py
+++ b/azure-python/__main__.py
@@ -1,8 +1,8 @@
 """An Azure RM Python Pulumi program"""
 
 import pulumi
-from pulumi_azure_native.storage import latest as storage
-from pulumi_azure_native.resources import latest as resources
+from pulumi_azure_native import storage
+from pulumi_azure_native import resources
 
 # Create an Azure Resource Group
 resource_group = resources.ResourceGroup('resource_group')


### PR DESCRIPTION
After making Azure-native the default, some of the current templates still have references to the deprecated `latest` namespace/module, so this updates the templates to use the top-level namespace/module.