### PR TITLE
Try node 16

### DIFF
--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest]
         go-version: [1.16.x]
-        node-version: [14.x]
+        node-version: [16.x]
         python-version: [3.7]
         dotnet: [3.1.x]
         pulumi-version: [latest]


### PR DESCRIPTION
Something was going pear-shaped with npm itself on version 6.14.13. 

Playing here with the idea of simply upgrading Node. Judging from this:

https://nodejs.org/en/about/releases/

We might benefit form being on 16.x?

```
   --- FAIL: TestTemplates/aws-typescript (184.41s)

   https://github.com/pulumi/templates/runs/3044949107?check_suite_focus=true


   template_test.go:107: STDERR: Logging in using access token from PULUMI_ACCESS_TOKEN
   npm ERR! cb() never called!

   npm ERR! This is an error with npm itself. Please report this error at:
   npm ERR!     <https://npm.community>

   npm ERR! A complete log of this run can be found in:
   npm ERR!     /home/runner/.npm/_logs/2021-07-12T09_20_38_623Z-debug.log
   error: npm install failed; rerun manually to try again, then run 'pulumi up' to perform an initial deployment: exit status 1


   /opt/hostedtoolcache/node/14.17.1/x64/bin/npm --version
   6.14.13

```