### PR TITLE
fix for failed builds fetching nuget packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet }}
-      - if: contains(matrix.platform, 'windows')
-        name: DotNet clean on windows
+      - if: contains(matrix.platform, 'ubuntu') || contains(matrix.platform, 'windows')
+        name: DotNet clean on windows and ubuntu
         run: |
           dotnet nuget locals all --clear
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -37,8 +37,8 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet }}
-      - if: contains(matrix.platform, 'windows')
-        name: DotNet clean on windows
+      - if: contains(matrix.platform, 'ubuntu') || contains(matrix.platform, 'windows')
+        name: DotNet clean on windows and ubuntu
         run: |
           dotnet nuget locals all --clear
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Ubuntu latest was failing on:
- Run Template Tests Against Latest CLI + Dev CLI
- Run Template Tests on Push or as Part of a Release

With errors of 
```
        /tmp/test-env018029435/test-env018029435.fsproj : error NU1102: Unable to find package Pulumi with version (>= 3.11.0)
        /tmp/test-env018029435/test-env018029435.fsproj : error NU1102:   - Found 1532 version(s) in nuget.org [ Nearest version: 3.11.0-alpha.1629906058 ]
```

Performing a clean before run has now produced the following success runs:
- https://github.com/pulumi/templates/runs/3479794426?check_suite_focus=true
- https://github.com/pulumi/templates/runs/3478973737?check_suite_focus=true