### PR TITLE
chore: bump from node v10 to v14

### DIFF
--- a/alicloud-typescript/package.json
+++ b/alicloud-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^10.0.0"
+        "@types/node": "^14"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/aws-typescript/package.json
+++ b/aws-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^10.0.0"
+        "@types/node": "^14"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/azure-classic-typescript/package.json
+++ b/azure-classic-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^10.0.0"
+        "@types/node": "^14"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/azure-typescript/package.json
+++ b/azure-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^10.0.0"
+        "@types/node": "^14"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/digitalocean-typescript/package.json
+++ b/digitalocean-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^10.0.0"
+        "@types/node": "^14"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/equinix-metal-typescript/package.json
+++ b/equinix-metal-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^10.0.0"
+        "@types/node": "^14"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/gcp-typescript/package.json
+++ b/gcp-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^10.0.0"
+        "@types/node": "^14"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/google-native-typescript/package.json
+++ b/google-native-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^10.0.0"
+        "@types/node": "^14"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.1.0",

--- a/kubernetes-typescript/package.json
+++ b/kubernetes-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^10.0.0"
+        "@types/node": "^14"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/linode-typescript/package.json
+++ b/linode-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^10.0.0"
+        "@types/node": "^14"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/openstack-typescript/package.json
+++ b/openstack-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^10.0.0"
+        "@types/node": "^14"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^10.0.0"
+        "@types/node": "^14"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0"


### PR DESCRIPTION
We probably want to use Node 14, as it's recommended for most applications. Node v10 is EOL.
