### PR TITLE
Push kubernetes-go golang minimum to 1.16

### DIFF
--- a/kubernetes-go/go.mod
+++ b/kubernetes-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.14
+go 1.16
 
 require (
 	github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.8.1


### PR DESCRIPTION
Go 1.16 adds embed (used by the SDK). This bumps from 1.14 -> 1.16

Currently, on a bone stock Debian system, when you run `pulumi new kubernetes-go` you get

```
indrora@debkube:~/quickstart$ pulumi new kubernetes-go
This command will walk you through creating a new Pulumi project.

Enter a value or leave blank to accept the (default), and press <ENTER>.
Press ^C at any time to quit.

project name: quickstart
Sorry, 'quickstart' is not a valid project name. A project with this name already exists.
project name: quickstart
project description: (A minimal Kubernetes Go Pulumi program)
Created project 'quickstart'

Please enter your desired stack name.
To create a stack in an organization, use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).
stack name: (dev)
Created stack 'dev'

Installing dependencies...

go: downloading github.com/pulumi/pulumi/sdk/v3 v3.15.0
go: downloading github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.8.1
go: downloading sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0
go: downloading golang.org/x/net v0.0.0-20200602114024-627f9648deb9
go: downloading github.com/uber/jaeger-client-go v2.22.1+incompatible
go: downloading google.golang.org/grpc v1.29.1
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/hashicorp/go-multierror v1.0.0
go: downloading github.com/golang/protobuf v1.4.2
go: downloading golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6
go: downloading github.com/blang/semver v3.5.1+incompatible
go: downloading golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2
go: downloading google.golang.org/protobuf v1.24.0
go: downloading github.com/opentracing/basictracer-go v1.0.0
go: downloading github.com/gogo/protobuf v1.3.1
go: downloading google.golang.org/genproto v0.0.0-20200608115520-7c474a2e3482
go: downloading github.com/mitchellh/go-ps v1.0.0
go: downloading github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
go: downloading github.com/opentracing/opentracing-go v1.1.0
go: downloading github.com/spf13/cobra v1.0.0
go: downloading github.com/google/go-cmp v0.4.1
go: downloading github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
go: downloading golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
go: downloading github.com/hashicorp/errwrap v1.0.0
go: downloading github.com/stretchr/testify v1.6.1
go: downloading github.com/inconshreveable/mousetrap v1.0.0
go: downloading pgregory.net/rapid v0.4.7
go: downloading gopkg.in/yaml.v2 v2.2.8
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading gopkg.in/src-d/go-git.v4 v4.13.1
go: downloading golang.org/x/text v0.3.2
go: downloading github.com/cheggaaa/pb v1.0.18
go: downloading go.uber.org/atomic v1.6.0
go: downloading gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
go: downloading github.com/uber/jaeger-lib v2.2.0+incompatible
go: downloading gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
go: downloading github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7
go: downloading github.com/djherbis/times v1.2.0
go: downloading github.com/gofrs/flock v0.7.1
go: downloading gopkg.in/src-d/go-billy.v4 v4.3.2
go: downloading github.com/kr/pretty v0.2.1
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99
go: downloading github.com/emirpasic/gods v1.12.0
go: downloading github.com/gofrs/uuid v3.3.0+incompatible
go: downloading github.com/sergi/go-diff v1.1.0
go: downloading github.com/spf13/pflag v1.0.5
go: downloading github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6
go: downloading github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd
go: downloading github.com/mitchellh/go-homedir v1.1.0
go: downloading gopkg.in/src-d/go-git-fixtures.v3 v3.5.0
go: downloading github.com/mattn/go-runewidth v0.0.8
go: downloading github.com/xanzy/ssh-agent v0.2.1
go: downloading github.com/kr/text v0.2.0
go: downloading golang.org/x/lint v0.0.0-20200302205851-738671d3881b
go: downloading github.com/mattn/go-colorable v0.1.6
go: downloading gopkg.in/cheggaaa/pb.v1 v1.0.28
go: downloading github.com/mattn/go-isatty v0.0.12
go: downloading github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
go: downloading github.com/gliderlabs/ssh v0.2.2
go: downloading github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94
go: downloading github.com/fatih/color v1.9.0
go: downloading golang.org/x/tools v0.0.0-20200608174601-1b747fd94509
go: downloading github.com/src-d/gcfg v1.4.0
go: downloading github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239
go: downloading github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
go: downloading gopkg.in/warnings.v0 v0.1.2
go: downloading github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
go: downloading golang.org/x/mod v0.3.0
go: downloading github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7
quickstart imports
        github.com/pulumi/pulumi/sdk/v3/go/pulumi imports
        github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin imports
        github.com/pulumi/pulumi/sdk/v3/go/common/apitype imports
        embed: package embed is not in GOROOT (/usr/lib/go-1.15/src/embed)
error: `go mod tidy` failed to install dependencies; rerun manually to try again, then run 'pulumi up' to perform an initial deployment: exit status 1
```