### PR TITLE
Ensure .NET projects always get the latest Pulumi package

### DIFF
--- a/alicloud-csharp/${PROJECT}.csproj
+++ b/alicloud-csharp/${PROJECT}.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Alicloud" Version="3.*" />
   </ItemGroup>
 

--- a/alicloud-fsharp/${PROJECT}.fsproj
+++ b/alicloud-fsharp/${PROJECT}.fsproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.FSharp" Version="3.*" />
     <PackageReference Include="Pulumi.Alicloud" Version="3.*" />
   </ItemGroup>

--- a/alicloud-visualbasic/${PROJECT}.vbproj
+++ b/alicloud-visualbasic/${PROJECT}.vbproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Alicloud" Version="3.*" />
   </ItemGroup>
 

--- a/aws-csharp/${PROJECT}.csproj
+++ b/aws-csharp/${PROJECT}.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Aws" Version="4.*" />
   </ItemGroup>
 

--- a/aws-fsharp/${PROJECT}.fsproj
+++ b/aws-fsharp/${PROJECT}.fsproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.FSharp" Version="3.*" />
     <PackageReference Include="Pulumi.Aws" Version="4.*" />
   </ItemGroup>

--- a/aws-visualbasic/${PROJECT}.vbproj
+++ b/aws-visualbasic/${PROJECT}.vbproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Aws" Version="4.*" />
   </ItemGroup>
 

--- a/azure-classic-csharp/${PROJECT}.csproj
+++ b/azure-classic-csharp/${PROJECT}.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Azure" Version="4.*" />
   </ItemGroup>
 

--- a/azure-classic-fsharp/${PROJECT}.fsproj
+++ b/azure-classic-fsharp/${PROJECT}.fsproj
@@ -11,8 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi.Azure" Version="4.*" />
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.FSharp" Version="3.*" />
+    <PackageReference Include="Pulumi.Azure" Version="4.*" />
   </ItemGroup>
 
 </Project>

--- a/azure-classic-visualbasic/${PROJECT}.vbproj
+++ b/azure-classic-visualbasic/${PROJECT}.vbproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Azure" Version="4.*" />
   </ItemGroup>
 

--- a/azure-csharp/${PROJECT}.csproj
+++ b/azure-csharp/${PROJECT}.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.AzureNative" Version="1.*" />
   </ItemGroup>
 

--- a/azure-fsharp/${PROJECT}.fsproj
+++ b/azure-fsharp/${PROJECT}.fsproj
@@ -11,8 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi.AzureNative" Version="1.*" />
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.FSharp" Version="3.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="1.*" />
   </ItemGroup>
 
 </Project>

--- a/fsharp/${PROJECT}.fsproj
+++ b/fsharp/${PROJECT}.fsproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.FSharp" Version="3.*" />
   </ItemGroup>
 

--- a/gcp-csharp/${PROJECT}.csproj
+++ b/gcp-csharp/${PROJECT}.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Gcp" Version="5.*" />
   </ItemGroup>
 

--- a/gcp-fsharp/${PROJECT}.fsproj
+++ b/gcp-fsharp/${PROJECT}.fsproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.FSharp" Version="3.*" />
     <PackageReference Include="Pulumi.Gcp" Version="5.*" />
   </ItemGroup>

--- a/gcp-visualbasic/${PROJECT}.vbproj
+++ b/gcp-visualbasic/${PROJECT}.vbproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Gcp" Version="5.*" />
   </ItemGroup>
 

--- a/google-native-csharp/${PROJECT}.csproj
+++ b/google-native-csharp/${PROJECT}.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.GoogleNative" Version="0.*" />
   </ItemGroup>
 

--- a/kubernetes-csharp/${PROJECT}.csproj
+++ b/kubernetes-csharp/${PROJECT}.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.*" />
   </ItemGroup>
 

--- a/kubernetes-fsharp/${PROJECT}.fsproj
+++ b/kubernetes-fsharp/${PROJECT}.fsproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.FSharp" Version="3.*" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.*" />
   </ItemGroup>


### PR DESCRIPTION
This change ensures the .NET projects always get the latest `Pulumi` package. Otherwise, the `Pulumi` package is a transitive dependency that is resolved to the **lowest** version that matches the requirements of the package that depends on it.

Fixes #230