### PR TITLE
Upate @pulumi/gcp version

### DIFF
--- a/gcp-typescript/package.json
+++ b/gcp-typescript/package.json
@@ -5,6 +5,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/gcp": "^5.0.0"
+        "@pulumi/gcp": "^6.0.0"
     }
 }


### PR DESCRIPTION
in oder to use the lates version of the GCP Pulumi provider the package.json is updated to use the version ^6.0.0