### PR TITLE
feat: digitalocean:token as config in Pulumi.yaml

### DIFF
--- a/digitalocean-go/Pulumi.yaml
+++ b/digitalocean-go/Pulumi.yaml
@@ -3,3 +3,7 @@ description: ${DESCRIPTION}
 runtime: go
 template:
   description: A minimal DigitalOcean Go Pulumi program
+  config:
+    digitalocean:token:
+      description: The token that allows you access your DigitalOcean account
+      secret: true

--- a/digitalocean-javascript/Pulumi.yaml
+++ b/digitalocean-javascript/Pulumi.yaml
@@ -3,3 +3,7 @@ description: ${DESCRIPTION}
 runtime: nodejs
 template:
   description: A minimal DigitalOcean JavaScript Pulumi program
+  config:
+    digitalocean:token:
+      description: The token that allows you access your DigitalOcean account
+      secret: true

--- a/digitalocean-python/Pulumi.yaml
+++ b/digitalocean-python/Pulumi.yaml
@@ -3,3 +3,7 @@ description: ${DESCRIPTION}
 runtime: python
 template:
   description: A minimal DigitalOcean Python Pulumi program
+  config:
+    digitalocean:token:
+      description: The token that allows you access your DigitalOcean account
+      secret: true

--- a/digitalocean-typescript/Pulumi.yaml
+++ b/digitalocean-typescript/Pulumi.yaml
@@ -3,3 +3,7 @@ description: ${DESCRIPTION}
 runtime: nodejs
 template:
   description: A minimal DigitalOcean TypeScript Pulumi program
+  config:
+    digitalocean:token:
+      description: The token that allows you access your DigitalOcean account
+      secret: true


### PR DESCRIPTION
Hi,

This PR adds the digitalocean:token as config into the Pulumi.yaml.

I used the template the last times quite often und had to set the token via `pulumi config...`