### PR TITLE
Shorten storage account name in Azure YAML

### DIFF
--- a/azure-yaml/Pulumi.yaml
+++ b/azure-yaml/Pulumi.yaml
@@ -14,7 +14,7 @@ resources:
   resourceGroup:
     type: azure-native:resources:ResourceGroup
   # Create an Azure resource (Storage Account)
-  storageAccount:
+  sa:
     type: azure-native:storage:StorageAccount
     properties:
       resourceGroupName: ${resourceGroup.name}
@@ -28,7 +28,7 @@ variables:
       Function: azure-native:storage:listStorageAccountKeys
       Arguments:
         resourceGroupName: ${resourceGroup.name}
-        accountName: ${storageAccount.name}
+        accountName: ${sa.name}
 
 outputs:
   # Export the primary key of the Storage Account

--- a/azure-yaml/Pulumi.yaml.append
+++ b/azure-yaml/Pulumi.yaml.append
@@ -4,7 +4,7 @@ resources:
   resourceGroup:
     type: azure-native:resources:ResourceGroup
   # Create an Azure resource (Storage Account)
-  storageAccount:
+  sa:
     type: azure-native:storage:StorageAccount
     properties:
       resourceGroupName: ${resourceGroup.name}
@@ -18,7 +18,7 @@ variables:
       Function: azure-native:storage:listStorageAccountKeys
       Arguments:
         resourceGroupName: ${resourceGroup.name}
-        accountName: ${storageAccount.name}
+        accountName: ${sa.name}
 
 outputs:
   # Export the primary key of the Storage Account


### PR DESCRIPTION
Otherwise the default program fails with

> Code="AccountNameInvalid" Message="storageAccount6289248d is not a valid storage account name. Storage account name must be between 3 and 24 characters in length and use numbers and lower-case letters only."