### PR TITLE
Add `location` to `azure-java` template config

### DIFF
--- a/azure-java/Pulumi.yaml
+++ b/azure-java/Pulumi.yaml
@@ -2,7 +2,7 @@ name: ${PROJECT}
 description: ${DESCRIPTION}
 runtime: java
 template:
-  description: "A minimal Azure Native Java Pulumi program"
+  description: A minimal Azure Native Java Pulumi program
   important: true
   config:
     azure-native:location:

--- a/azure-java/Pulumi.yaml
+++ b/azure-java/Pulumi.yaml
@@ -2,4 +2,9 @@ name: ${PROJECT}
 description: ${DESCRIPTION}
 runtime: java
 template:
-  description: A minimal Azure Native Java Pulumi program
+  description: "A minimal Azure Native Java Pulumi program"
+  important: true
+  config:
+    azure-native:location:
+      description: The Azure location to use
+      default: WestUS


### PR DESCRIPTION
Without this, we get the following first-run experience:

```
Diagnostics:
  azure-native:resources:ResourceGroup (resourceGroup):
    error: azure-native:resources:ResourceGroup resource 'resourceGroup' has a problem: missing required property 'location'. Either set it explicitly or configure it with 'pulumi config set azure-native:location <value>'.
```