### PR TITLE
Change the name of the bucket resource to my-bucket

### DIFF
--- a/aws-yaml/Pulumi.yaml
+++ b/aws-yaml/Pulumi.yaml
@@ -11,9 +11,9 @@ template:
 
 resources:
   # Create an AWS resource (S3 Bucket)
-  bucket:
+  my-bucket:
     type: aws:s3:Bucket
 
 outputs:
   # Export the name of the bucket
-  bucketName: ${bucket.id}
+  bucketName: ${my-bucket.id}

--- a/gcp-yaml/Pulumi.yaml.append
+++ b/gcp-yaml/Pulumi.yaml.append
@@ -1,11 +1,11 @@
 
 resources:
   # Create a GCP resource (Storage Bucket)
-  bucket:
+  my-bucket:
     type: gcp:storage:Bucket
     properties:
       location: US
 
 outputs:
   # Export the DNS name of the bucket
-  bucketName: ${bucket.url}
+  bucketName: ${my-bucket.url}


### PR DESCRIPTION
Going through the recent additions to the getting-started guides, I noticed we use the resource name `bucket` in these two templates, but we use `my-bucket` in all of the others. Since we have shared code in our guides that refers to this bucket as `my-bucket`, it'd be nice to update it here, both for consistency and to keep from having to special-case a bunch of the prose in the guides. Thank you!

 