### PR TITLE
Add `project` to `gcp-java` template config

### DIFF
--- a/gcp-java/Pulumi.yaml
+++ b/gcp-java/Pulumi.yaml
@@ -3,3 +3,7 @@ description: ${DESCRIPTION}
 runtime: java
 template:
   description: A minimal Google Cloud Java Pulumi program
+  important: true
+  config:
+    gcp:project:
+      description: The Google Cloud project to deploy into


### PR DESCRIPTION
Without this, we get the following first-run experience:

```
Diagnostics:
  pulumi:pulumi:Stack (quickstart-dev):
    error: update failed
 
  gcp:storage:Bucket (my-bucket):
    error: 1 error occurred:
        * project: required field is not set
```

Looks like all other `gcp-*` templates have this as well.