### PR TITLE
Opt out of TypeScript in JavaScript templates

### DIFF
--- a/alicloud-javascript/Pulumi.yaml
+++ b/alicloud-javascript/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 template:
   description: A minimal AliCloud JavaScript Pulumi program
   config:

--- a/auth0-javascript/Pulumi.yaml
+++ b/auth0-javascript/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 template:
   description: A minimal Auth0 TypeScript Pulumi program
   config:

--- a/aws-javascript/Pulumi.yaml
+++ b/aws-javascript/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 template:
   description: A minimal AWS JavaScript Pulumi program
   important: true

--- a/aws-native-javascript/Pulumi.yaml
+++ b/aws-native-javascript/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 template:
   description: A minimal AWS JavaScript Pulumi program
   config:

--- a/azure-classic-javascript/Pulumi.yaml
+++ b/azure-classic-javascript/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 template:
   description: A minimal JavaScript Pulumi program with the classic Azure provider
   config:

--- a/azure-javascript/Pulumi.yaml
+++ b/azure-javascript/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 template:
   description: A minimal JavaScript Pulumi program with the native Azure provider
   important: true

--- a/civo-javascript/Pulumi.yaml
+++ b/civo-javascript/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 template:
   description: A minimal Civo TypeScript Pulumi program
   config:

--- a/digitalocean-javascript/Pulumi.yaml
+++ b/digitalocean-javascript/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 template:
   description: A minimal DigitalOcean JavaScript Pulumi program

--- a/equinix-metal-javascript/Pulumi.yaml
+++ b/equinix-metal-javascript/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 template:
   description: A minimal Equinix Metal JavaScript Pulumi program

--- a/gcp-javascript/Pulumi.yaml
+++ b/gcp-javascript/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 template:
   description: A minimal Google Cloud JavaScript Pulumi program
   important: true

--- a/github-javascript/Pulumi.yaml
+++ b/github-javascript/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 template:
   description: A minimal GitHub JavaScript Pulumi program.
   config:

--- a/hello-aws-javascript/Pulumi.yaml
+++ b/hello-aws-javascript/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 template:
   description: A simple AWS serverless JavaScript Pulumi program
   config:

--- a/javascript/Pulumi.yaml
+++ b/javascript/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 template:
   description: A minimal JavaScript Pulumi program

--- a/kubernetes-javascript/Pulumi.yaml
+++ b/kubernetes-javascript/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 template:
   description: A minimal Kubernetes JavaScript Pulumi program
   important: true

--- a/linode-javascript/Pulumi.yaml
+++ b/linode-javascript/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 template:
   description: A minimal Linode JavaScript Pulumi program
   config:

--- a/oci-javascript/Pulumi.yaml
+++ b/oci-javascript/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 template:
   description: A minimal OCI JavaScript Pulumi program

--- a/openstack-javascript/Pulumi.yaml
+++ b/openstack-javascript/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 template:
   description: A minimal OpenStack JavaScript Pulumi program


### PR DESCRIPTION
Projects that do not use TypeScript still pay some TypeScript-related overheads inside Pulumi. One overhead is `import "typescript"` in nodejs costing 300ms. `pulumi-language-nodejs` currently thinks that every project is a TypeScript project, it does not autodetect; unless it is told otherwise using this option. While we could consider auto-detection, I am afraid it might break some projects out there; so the safer path in this PR is to opt out of TypeScript explicitly for all the JavaScript templates so the new projects take advantage of the related optimizations.