### PR TITLE
Withhold broken kubernetes provider update

### DIFF
--- a/kubernetes-java/pom.xml
+++ b/kubernetes-java/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.pulumi</groupId>
             <artifactId>kubernetes</artifactId>
-            <version>(,4.0.0]</version>
+            <version>3.19.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Last known working version 3.19.1

This fixes `pulumi new java-kubernetes` for now.

Once https://github.com/pulumi/pulumi-java/issues/774 fix lands in a new version of Java Kubernetes SDK we might want to go back to a floating reference in the template.

