### PR TITLE
Consistent test options

### DIFF
--- a/tests/performance_test.go
+++ b/tests/performance_test.go
@@ -23,6 +23,10 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+func isTracingEnabled() bool {
+	return traces.IsTracingEnabled()
+}
+
 func guessBench(template workspace.Template) traces.Benchmark {
 	b := traces.NewBenchmark(template.Name)
 	b.Provider = guessProvider(template)

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -62,7 +62,7 @@ func TestTemplates(t *testing.T) {
 
 	base := integration.ProgramTestOptions{
 		ExpectRefreshChanges:   true,
-		Quick:                  true,
+		Quick:                  !isTracingEnabled(),
 		SkipRefresh:            true,
 		NoParallel:             true, // we mark tests as Parallel manually when instantiating
 		DestroyOnCleanup:       true,

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -61,7 +61,7 @@ func TestTemplates(t *testing.T) {
 	}
 
 	// When tracing is enabled to collect performance data, using
-	// Quick: true skews the measurements, therefore prefor Quick:
+	// Quick: true skews the measurements, therefore prefer Quick:
 	// false in that case.
 	quick := !isTracingEnabled()
 

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -60,9 +60,14 @@ func TestTemplates(t *testing.T) {
 		templateUrl = specificTemplate
 	}
 
+	// When tracing is enabled to collect performance data, using
+	// Quick: true skews the measurements, therefore prefor Quick:
+	// false in that case.
+	quick := !isTracingEnabled()
+
 	base := integration.ProgramTestOptions{
 		ExpectRefreshChanges:   true,
-		Quick:                  !isTracingEnabled(),
+		Quick:                  quick,
 		SkipRefresh:            true,
 		NoParallel:             true, // we mark tests as Parallel manually when instantiating
 		DestroyOnCleanup:       true,


### PR DESCRIPTION
Do not use Quick: True when performance testing, as it skews the benchmarks. 

https://github.com/pulumi/home/issues/1498

Test run: https://github.com/pulumi/templates/runs/7954302544?check_suite_focus=true