### PR TITLE
Fix make test_template targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test_templates::
 # Example: make test_template.typescript
 # This will run a test corresponding to the typescript template.
 test_template.%:
-	cd tests && BLACK_LISTED_TESTS=none go test -run "TestTemplate/^$*$$" $(TESTFLAGS)
+	cd tests && PULUMI_TEMPLATE_LOCATION=${PWD} BLACK_LISTED_TESTS=none go test -run "TestTemplate/^$*$$" $(TESTFLAGS)
 
 # Every template doubles up as a benchmark.
 # Example: make bench_template.typescript
@@ -17,7 +17,7 @@ test_template.%:
 # See also https://www.pulumi.com/docs/support/troubleshooting/#performance
 bench_template.%:
 	mkdir -p ./traces
-	cd tests && PULUMI_TRACING_DIR=${PWD}/traces BLACK_LISTED_TESTS=none go test -run "TestTemplate/^$*$$" $(TESTFLAGS)
+	cd tests && PULUMI_TEMPLATE_LOCATION=${PWD} PULUMI_TRACING_DIR=${PWD}/traces BLACK_LISTED_TESTS=none go test -run "TestTemplate/^$*$$" $(TESTFLAGS)
 
 ensure::
 	cd tests && go mod download


### PR DESCRIPTION
I'm not entirely sure what the go test is doing by default to find the list of templates, but it's not scanning the folder. So when adding new templates make test_tempate target is broken. This works around it.