### PR TITLE
More generous timeouts

### DIFF
--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const testTimeout = 30 * time.Minute
+const testTimeout = 60 * time.Minute
 
 func TestTemplates(t *testing.T) {
 	blackListedTests := os.Getenv("BLACK_LISTED_TESTS")


### PR DESCRIPTION
https://github.com/pulumi/templates/actions/workflows/cron.yml seeing quite a few timeout related failures. It's not great we have templates timing out in 30min but some of it seems to be an artifact of the CI environment (cannot repro locally). The higher timeout would let us focus on the few tests that do get stuck.