### PR TITLE
Use a more unique bucket name

### DIFF
--- a/aws-native-fsharp/Program.fs
+++ b/aws-native-fsharp/Program.fs
@@ -6,7 +6,7 @@ open Pulumi.AwsNative.S3
 let infra () =
 
   // Create an AWS resource (S3 Bucket)
-  let bucket = Bucket "my-bucket"
+  let bucket = Bucket "my-aws-native-fsharp-bucket"
 
   // Export the name of the bucket
   dict [("bucketName", bucket.Id :> obj)]


### PR DESCRIPTION
The name was so common it generated hash collisions failing tests https://github.com/pulumi/templates/runs/8032164262?check_suite_focus=true#step:19:406 even though Pulumi disambiguates resources randomly.