### PR TITLE
Use go 1.18.x toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-latest]
-        go-version: [1.17.x]
+        go-version: [1.18.x]
         node-version: [14.x]
         python-version: [3.7]
         dotnet: [6.0.x]
@@ -64,7 +64,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
       - run: go env

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-latest]
-        go-version: [1.17.x]
+        go-version: [1.18.x]
         node-version: [14.x]
         python-version: [3.7]
         dotnet: [6.0.x]
@@ -60,7 +60,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
       - if: matrix.pulumi-version == 'latest'

--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        go-version: [1.17.x]
+        go-version: [1.18.x]
         node-version: [14.x]
         python-version: [3.7]
         dotnet: [6.0.x]
@@ -62,7 +62,7 @@ jobs:
         with:
           python-version: ${{matrix.python-version}}
       - name: Install Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: ${{matrix.go-version}}
       - name: Install Python Deps

--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest]
-        go-version: [1.17.x]
+        go-version: [1.18.x]
         node-version: [14.x]
         python-version: [3.7]
         dotnet: [6.0.x]
@@ -69,7 +69,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
       - run: go env


### PR DESCRIPTION
I've noticed that Go-based template tests started failing. The underlying issue is https://github.com/pulumi/pulumi/issues/10864 as Pulumi dropped 1.17 support it seems in a recent release.

According to https://endoflife.date/go though support for 1.17 ended 1 months ago, so moving the tests to Go 1.18 is reasonable as it will represent a broader set of our users. We could test more versions but likely not enough CI capacity yet.

CC @AaronFriel 
