### PR TITLE
Always cleanup the temp dirs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-region: ${{ env.AWS_REGION }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 3600
+          role-duration-seconds: 14400 # 4 hours
           role-session-name: templates@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
       - name: Authenticate to Google Cloud

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -95,7 +95,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-region: ${{ env.AWS_REGION }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 3600
+          role-duration-seconds: 14400 # 4 hours
           role-session-name: templates@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
       - name: Authenticate to Google Cloud

--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -98,7 +98,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-region: ${{ env.AWS_REGION }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 3600
+          role-duration-seconds: 14400 # 4 hours
           role-session-name: templates@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
       - name: Authenticate to Google Cloud

--- a/tests/internal/testutils/config.go
+++ b/tests/internal/testutils/config.go
@@ -14,7 +14,6 @@ type TemplateTestConfig struct {
 	Config      map[string]string
 	TemplateUrl string
 	Skipped     []string
-	CI          bool
 	SkipEnvVar  string
 }
 
@@ -66,14 +65,7 @@ func NewTemplateTestConfigFromEnv(skipEnvVar string) TemplateTestConfig {
 		fmt.Printf("Using templates from PULUMI_TEMPLATE_LOCATION=%s\n", loc)
 	}
 
-	ci := false
-	if ciValue, found := os.LookupEnv("CI"); found {
-		ci = true
-		fmt.Printf("Assume running on a CI system based on env var CI=%s\n", ciValue)
-	}
-
 	return TemplateTestConfig{
-		CI:          ci,
 		SkipEnvVar:  skipEnvVar,
 		Skipped:     skipped,
 		TemplateUrl: templateUrl,

--- a/tests/internal/testutils/environments.go
+++ b/tests/internal/testutils/environments.go
@@ -22,10 +22,6 @@ func NewEnvironment(t *testing.T, cfg TemplateTestConfig) *ptesting.Environment 
 // deleteIfNotFailed deletes the files in the testing environment if the testcase has
 // not failed. (Otherwise they are left to aid debugging.)
 func deleteIfNotFailed(e *ptesting.Environment, cfg TemplateTestConfig) {
-	if cfg.CI {
-		// Skip cleanup on CI, workaround for https://github.com/pulumi/pulumi/issues/9437
-		return
-	}
 	if !e.T.Failed() {
 		e.DeleteEnvironment()
 	}


### PR DESCRIPTION
Likely the CI out of disk space issues occur because we don't clean up the temp folders. https://github.com/pulumi/pulumi/issues/9437 seems to be closed now. Should it be safe to re-enable cleaning the temp folders on CI?

Fixes #370 also