### PR TITLE
Skip container-* tests on Windows and Mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,9 +125,26 @@ jobs:
         env:
           PULUMI_PYTHON_CMD: python
           TESTPARALLELISM: 3
-          SKIPPED_TESTS: "${{ env.SKIPPED_TESTS }},container-"
-      - if: contains(matrix.platform, 'macOS') || contains(matrix.platform, 'ubuntu')
-        name: Running non-Windows tests
+          SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container"
+      - if: contains(matrix.platform, 'windows')
+        name: Running Windows tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd tests && go test -v -json -count=1 -cover -timeout 6h -parallel ${{ env.TESTPARALLELISM }} . 2>&1 | gotestfmt
+        env:
+          PULUMI_PYTHON_CMD: python
+          TESTPARALLELISM: 3
+          SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container"
+      - if: contains(matrix.platform, 'macos')
+        name: Running macOS tests
+        run: |
+          set -euo pipefail
+          cd tests && go test -v -json -count=1 -cover -timeout 6h -parallel ${{ env.TESTPARALLELISM }} . 2>&1 | gotestfmt
+        env:
+          SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container"
+      - if: contains(matrix.platform, 'ubuntu')
+        name: Running Linux tests
         run: |
           set -euo pipefail
           cd tests && go test -v -json -count=1 -cover -timeout 6h -parallel ${{ env.TESTPARALLELISM }} . 2>&1 | gotestfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
         env:
           PULUMI_PYTHON_CMD: python
           TESTPARALLELISM: 3
+          SKIPPED_TESTS: "${{ env.SKIPPED_TESTS }},container-"
       - if: contains(matrix.platform, 'macOS') || contains(matrix.platform, 'ubuntu')
         name: Running non-Windows tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,16 +126,6 @@ jobs:
           PULUMI_PYTHON_CMD: python
           TESTPARALLELISM: 3
           SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container"
-      - if: contains(matrix.platform, 'windows')
-        name: Running Windows tests
-        shell: bash
-        run: |
-          set -euo pipefail
-          cd tests && go test -v -json -count=1 -cover -timeout 6h -parallel ${{ env.TESTPARALLELISM }} . 2>&1 | gotestfmt
-        env:
-          PULUMI_PYTHON_CMD: python
-          TESTPARALLELISM: 3
-          SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container"
       - if: contains(matrix.platform, 'macos')
         name: Running macOS tests
         run: |

--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -130,8 +130,16 @@ jobs:
         env:
           PULUMI_PYTHON_CMD: python
           TESTPARALLELISM: 3
-      - if: contains(matrix.platform, 'macOS') || contains(matrix.platform, 'ubuntu')
-        name: Running non-Windows tests
+          SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container"
+      - if: contains(matrix.platform, 'macOS')
+        name: Running macOS tests
+        run: |
+          set -euo pipefail
+          cd tests && go test -v -json -count=1 -cover -timeout 6h -parallel ${{ env.TESTPARALLELISM }} . 2>&1 | gotestfmt
+        env:
+          SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container"
+      - if: contains(matrix.platform, 'ubuntu')
+        name: Running Linux tests
         run: |
           set -euo pipefail
           cd tests && go test -v -json -count=1 -cover -timeout 6h -parallel ${{ env.TESTPARALLELISM }} . 2>&1 | gotestfmt


### PR DESCRIPTION
Adjusts a couple of workflows to skip container-related template tests on Windows and Mac.

Fixes #386.