### PR TITLE
Update the gotestfmt organization

### DIFF
--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Install gotestfmt
         uses: jaxxstorm/action-install-gh-release@v1.3.1
         with:
-          repo: haveyoudebuggedit/gotestfmt
+          repo: gotesttools/gotestfmt
       - name: Get dependencies
         run: make ensure
       - if: contains(matrix.platform, 'windows')


### PR DESCRIPTION
The repository for one of the tools we use in CI has moved to another GitHub organization ([announcement here](https://github.com/GoTestTools/gotestfmt/discussions/46)). This change fixes things up.