### PR TITLE
Add template-metadata docs, fix a couple of metadata bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,29 @@ This repo contains the templates for `pulumi new`, which make it easy to quickly
 
 ## Adding a new template
 
- 1. Create a new directory for the template, e.g. `my-template-javascript`. By convention, hyphens are used to separate words and the language is included as a suffix.
+1. Create a new directory for the template, e.g. `my-template-javascript`. By convention, hyphens are used to separate words and the language is included as a suffix.
 
- 2. Add template files in the new directory.
+1. Add template files in the new directory.
+
+2. If the template is an architecture template, include the requisite supplemental metadata at `./metadata`:
+
+    * If the template adds to an existing template group (for example, if it's a new a `static-website-aws` template), add a new line for the template in the `templates` section of that group:
+
+        ```diff
+          name: AWS Static Website
+          ...
+          templates:
+            ...
+            - static-website-go
+            - static-website-csharp
+        -   - static-website-yaml
+        +   - static-website-yaml
+        +   - static-website-java
+        ```
+
+    * If the template introduces a new architecture, make a new entry in `./metadata/architectures.yaml` using the others as a guide (the keys and `slug` values correspond with these templates' eventual paths at <https://pulumi.com/templates>), then add a new file that lists the new template at `./metadata/groups/{architecture}-{cloud}-{language}.yaml`. Set the new group's `parent` property to match the key/name of the item you added to `architectures.yaml`.
+
+3. Request a review from the @pulumi/content-engineering team.
 
 ## Text replacement
 
@@ -16,4 +36,3 @@ The following special strings can be included in any template file; these will b
 
  - `${PROJECT}` - The name of the project.
  - `${DESCRIPTION}` - The description of the project.
-

--- a/metadata/groups/container-service-aws.yaml
+++ b/metadata/groups/container-service-aws.yaml
@@ -1,7 +1,7 @@
 name: Container Service on AWS
 kind: architecture
 parent: container-service
-slug: azure
+slug: aws
 clouds:
   - aws
 templates:

--- a/metadata/groups/serverless-application-aws.yaml
+++ b/metadata/groups/serverless-application-aws.yaml
@@ -1,7 +1,7 @@
 name: AWS Serverless Application
 kind: architecture
 parent: serverless-application
-slug: azure
+slug: aws
 clouds:
   - aws
 templates:


### PR DESCRIPTION
Adds a bit to the README about what to do when you create a new architecture template, and fixes a couple of typos in existing metadata files.