### PR TITLE
Fix non-templated TypeScript project names

### DIFF
--- a/container-azure-typescript/app/package.json
+++ b/container-azure-typescript/app/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "my-app",
+    "name": "${PROJECT}-app",
     "version": "0.1.0",
     "main": "index.js",
     "scripts": {

--- a/kubernetes-aws-typescript/package.json
+++ b/kubernetes-aws-typescript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "kubernetes-aws",
+    "name": "${PROJECT}",
     "devDependencies": {
         "@types/node": "^14"
     },

--- a/kubernetes-azure-typescript/package.json
+++ b/kubernetes-azure-typescript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "kubernetes-azure-typescript",
+    "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
         "@types/node": "^14"

--- a/kubernetes-gcp-typescript/package.json
+++ b/kubernetes-gcp-typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kubernetes-gcp-typescript",
+  "name": "${PROJECT}",
   "devDependencies": {
     "@types/node": "^14"
   },

--- a/serverless-azure-typescript/app/package.json
+++ b/serverless-azure-typescript/app/package.json
@@ -1,4 +1,4 @@
 {
-  "name": "hello-world",
-  "version": "0.0.1"
+  "name": "${PROJECT}-app",
+  "version": "0.1.0"
 }

--- a/serverless-azure-typescript/package.json
+++ b/serverless-azure-typescript/package.json
@@ -1,5 +1,5 @@
 {
-		"name": "templates-serverless-azure-typescript",
+		"name": "${PROJECT}",
 		"devDependencies": {
 			"@types/node": "^14"
 		},

--- a/serverless-gcp-typescript/app/package.json
+++ b/serverless-gcp-typescript/app/package.json
@@ -1,7 +1,6 @@
 {
-    "name": "serverless-gcp-nodejs",
-    "version": "0.0.1",
-    "private": true,
+    "name": "${PROJECT}-app",
+    "version": "0.1.0",
     "dependencies": {
         "@google-cloud/functions-framework": "^3.1.0"
     }

--- a/serverless-gcp-typescript/package.json
+++ b/serverless-gcp-typescript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "serverless-gcp-typescript",
+    "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
         "@types/node": "^14"

--- a/static-website-aws-typescript/package.json
+++ b/static-website-aws-typescript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "templates-static-website-aws-typescript",
+    "name": "${PROJECT}",
     "devDependencies": {
         "@types/node": "^14"
     },

--- a/static-website-azure-typescript/package.json
+++ b/static-website-azure-typescript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "templates-static-website-azure-typescript",
+    "name": "${PROJECT}",
     "devDependencies": {
         "@types/node": "^14"
     },

--- a/static-website-gcp-typescript/package.json
+++ b/static-website-gcp-typescript/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "templates-static-website-gcp-typescript",
+    "name": "${PROJECT}",
     "devDependencies": {
         "@types/node": "^14"
     },


### PR DESCRIPTION
Happened to notice these need to be templated also. (I'll also follow up with an issue to add some linting for this sort of thing!)