### PR TITLE
Add metadata for Kubernetes on Google Cloud

### DIFF
--- a/metadata/groups/kubernetes-gcp.yaml
+++ b/metadata/groups/kubernetes-gcp.yaml
@@ -9,3 +9,4 @@ templates:
   - kubernetes-gcp-python
   - kubernetes-gcp-go
   - kubernetes-gcp-yaml
+  - kubernetes-gcp-csharp

--- a/metadata/groups/kubernetes-gcp.yaml
+++ b/metadata/groups/kubernetes-gcp.yaml
@@ -1,0 +1,11 @@
+name: Kubernetes Cluster on Google Cloud
+kind: architecture
+parent: kubernetes
+slug: gcp
+clouds:
+  - gcp
+templates:
+  - kubernetes-gcp-typescript
+  - kubernetes-gcp-python
+  - kubernetes-gcp-go
+  - kubernetes-gcp-yaml


### PR DESCRIPTION
This PR adds a metadata/groups file for templates for Kubernetes on Google Cloud.