### PR TITLE
Add comma when reading eksNodeInstanceType config value

### DIFF
--- a/kubernetes-aws-python/__main__.py
+++ b/kubernetes-aws-python/__main__.py
@@ -7,7 +7,7 @@ config = pulumi.Config()
 min_cluster_size = config.get_float("minClusterSize", 3)
 max_cluster_size = config.get_float("maxClusterSize", 6)
 desired_cluster_size = config.get_float("desiredClusterSize", 3)
-eks_node_instance_type = config.get("eksNodeInstanceType" "t2.medium")
+eks_node_instance_type = config.get("eksNodeInstanceType", "t2.medium")
 vpc_network_cidr = config.get("vpcNetworkCidr", "10.0.0.0/16")
 
 # Create a VPC for the EKS cluster


### PR DESCRIPTION
There is a missing comma when reading the `eksNodeInstanceType` config value causing it to always evaluate to `None` since the key is getting implicitly concatenated to `eksNodeInstanceTypet3.medium`, which doesn't exist in the configuration. Adding the comma will cause the value to read in from the configuration.