### PR TITLE
Add `container-gcp-*` template metadata

### DIFF
--- a/metadata/groups/container-service-gcp.yaml
+++ b/metadata/groups/container-service-gcp.yaml
@@ -1,0 +1,11 @@
+name: Container Service on Google Cloud
+kind: architecture
+parent: container-service
+slug: gcp
+clouds:
+  - gcp
+templates:
+  - container-gcp-typescript
+  - container-gcp-python
+  - container-gcp-go
+  - container-gcp-csharp


### PR DESCRIPTION
I overlooked this file when I submitted the templates.