### PR TITLE
Fix Go module names

### DIFF
--- a/container-azure-go/go.mod
+++ b/container-azure-go/go.mod
@@ -1,4 +1,4 @@
-module azure-container-go
+module ${PROJECT}
 
 go 1.17
 

--- a/container-gcp-go/go.mod
+++ b/container-gcp-go/go.mod
@@ -1,4 +1,4 @@
-module container-gcp-go
+module ${PROJECT}
 
 go 1.17
 

--- a/kubernetes-aws-go/go.mod
+++ b/kubernetes-aws-go/go.mod
@@ -1,4 +1,4 @@
-module yaml
+module ${PROJECT}
 
 go 1.17
 

--- a/kubernetes-azure-go/go.mod
+++ b/kubernetes-azure-go/go.mod
@@ -1,4 +1,4 @@
-module kubernetes-azure-go
+module ${PROJECT}
 
 go 1.17
 

--- a/kubernetes-gcp-go/go.mod
+++ b/kubernetes-gcp-go/go.mod
@@ -1,4 +1,4 @@
-module tmp
+module ${PROJECT}
 
 go 1.17
 

--- a/serverless-aws-go/go.mod
+++ b/serverless-aws-go/go.mod
@@ -1,4 +1,4 @@
-module serveress-aws-go
+module ${PROJECT}
 
 go 1.17
 

--- a/serverless-azure-go/go.mod
+++ b/serverless-azure-go/go.mod
@@ -1,4 +1,4 @@
-module templates-serverless-azure-go
+module ${PROJECT}
 
 go 1.17
 

--- a/serverless-gcp-go/app/go.mod
+++ b/serverless-gcp-go/app/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/templates/serverless-gcp-go/api
+module example.com/${PROJECT}/api
 
 go 1.16
 

--- a/serverless-gcp-go/go.mod
+++ b/serverless-gcp-go/go.mod
@@ -1,4 +1,4 @@
-module serverless-gcp-go
+module ${PROJECT}
 
 go 1.17
 

--- a/static-website-aws-go/go.mod
+++ b/static-website-aws-go/go.mod
@@ -1,4 +1,4 @@
-module templates-static-website-aws-go
+module ${PROJECT}
 
 go 1.17
 

--- a/static-website-azure-go/go.mod
+++ b/static-website-azure-go/go.mod
@@ -1,4 +1,4 @@
-module templates-static-website-azure-go
+module ${PROJECT}
 
 go 1.17
 

--- a/static-website-gcp-go/go.mod
+++ b/static-website-gcp-go/go.mod
@@ -1,4 +1,4 @@
-module templates-static-website-gcp-go
+module ${PROJECT}
 
 go 1.17
 


### PR DESCRIPTION
These should be `${PROJECT}` as well, like the others. Includes a similar tweak to the module name of the GCP serverless function template's module name, which is slightly different because of GCP naming restrictions.