### PR TITLE
Fix exported origin URL

### DIFF
--- a/static-website-azure-typescript/index.ts
+++ b/static-website-azure-typescript/index.ts
@@ -71,7 +71,7 @@ const endpoint = new azure_native.cdn.Endpoint("endpoint", {
 });
 
 // Export the URLs and hostnames of the storage account and CDN.
-export const originURL = pulumi.interpolate`http://${originHostname}`;
+export const originURL = account.primaryEndpoints.apply(endpoints => endpoints.web);
 export { originHostname };
 export const cdnURL = pulumi.interpolate`https://${endpoint.hostName}`;
 export const cdnHostname = endpoint.hostName;


### PR DESCRIPTION
This is incorrect -- it should be the URL emitted by the storage account, as in the other languages of this template. (The endpoint actually isn't available over HTTP.) [Internal convo here](https://pulumi.slack.com/archives/C043485KTDW/p1667275877490969).