### PR TITLE
Add a test that ensures arch templates also exist

### DIFF
--- a/tests/metadata/metadata.test.js
+++ b/tests/metadata/metadata.test.js
@@ -83,5 +83,11 @@ describe("Template metadata", () => {
             expect(templates["gcp-yaml"]).toBeDefined();
             expect(templates["azure-java"]).toBeDefined();
         });
+
+        it("only contains templates that exist", () => {
+            Object.keys(templates).forEach(template => {
+                expect(() => fs.readdirSync(`${template}`)).not.toThrow();
+            });
+        });
     });
 });

--- a/tests/metadata/metadata.test.js
+++ b/tests/metadata/metadata.test.js
@@ -1,4 +1,5 @@
 const metadata = require("../../metadata/dist/metadata.json");
+const fs = require("fs");
 
 describe("Template metadata", () => {
 
@@ -29,6 +30,17 @@ describe("Template metadata", () => {
             expect(architectures.find(arch => arch.name === "Serverless")).toBeDefined();
             expect(architectures.find(arch => arch.name === "Container Service")).toBeDefined();
             expect(architectures.find(arch => arch.name === "Kubernetes")).toBeDefined();
+            expect(architectures.find(arch => arch.name === "Virtual Machine")).toBeDefined();
+        });
+
+        it("only lists templates that exist in the repository", () => {
+            architectures.forEach(arch => {
+                arch.groups.forEach(group => {
+                    group.templates.forEach(template => {
+                        expect(() => fs.readdirSync(`${template}`)).not.toThrow();
+                    });
+                });
+            });
         });
     });
 

--- a/tests/metadata/metadata.test.js
+++ b/tests/metadata/metadata.test.js
@@ -33,7 +33,7 @@ describe("Template metadata", () => {
             expect(architectures.find(arch => arch.name === "Virtual Machine")).toBeDefined();
         });
 
-        it("only lists templates that exist in the repository", () => {
+        it("only contains templates that exist in the repository", () => {
             architectures.forEach(arch => {
                 arch.groups.forEach(group => {
                     group.templates.forEach(template => {
@@ -84,7 +84,7 @@ describe("Template metadata", () => {
             expect(templates["azure-java"]).toBeDefined();
         });
 
-        it("only contains templates that exist", () => {
+        it("only contains templates that exist in the repository", () => {
             Object.keys(templates).forEach(template => {
                 expect(() => fs.readdirSync(`${template}`)).not.toThrow();
             });


### PR DESCRIPTION
The `metadata.json` file has an `architectures` section that lists the templates that belong to each architecture. Because we manage these lists by hand (by appending template names as strings to each template group), it's technically possible to list a template that doesn't actually exist, which could break consumers of this file (e.g., the Service) that rely on it for creating new projects. So this change adds a couple of tests to enure every template referenced in `metadata.json` also exists in the repository.