### PR TITLE
Fix Azure/Google Cloud Go-Container templates

### DIFF
--- a/container-azure-go/app/Dockerfile
+++ b/container-azure-go/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang
+FROM --platform=linux/amd64 golang
 WORKDIR /usr/src/app
 
 COPY go.* ./

--- a/container-gcp-go/app/Dockerfile
+++ b/container-gcp-go/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang
+FROM --platform=linux/amd64 golang
 WORKDIR /usr/src/app
 
 COPY go.* ./


### PR DESCRIPTION
The current template fails on M1 Macs due to the architecture differences. This change sidesteps the issue with env variables in Go with docker.Image.