### PR TITLE
Rename Kubernetes architecture to Kubernetes Cluster

### DIFF
--- a/metadata/architectures.yaml
+++ b/metadata/architectures.yaml
@@ -15,7 +15,7 @@ virtual-machine:
   slug: virtual-machine
 
 kubernetes:
-  name: Kubernetes
+  name: Kubernetes Cluster
   slug: kubernetes
 
 kubernetes-application:

--- a/metadata/dist/metadata.json
+++ b/metadata/dist/metadata.json
@@ -215,7 +215,7 @@
             ]
         },
         {
-            "name": "Kubernetes",
+            "name": "Kubernetes Cluster",
             "slug": "kubernetes",
             "groups": [
                 {

--- a/tests/metadata/metadata.test.js
+++ b/tests/metadata/metadata.test.js
@@ -29,7 +29,8 @@ describe("Template metadata", () => {
             expect(architectures.find(arch => arch.name === "Static Website")).toBeDefined();
             expect(architectures.find(arch => arch.name === "Serverless")).toBeDefined();
             expect(architectures.find(arch => arch.name === "Container Service")).toBeDefined();
-            expect(architectures.find(arch => arch.name === "Kubernetes")).toBeDefined();
+            expect(architectures.find(arch => arch.name === "Kubernetes Cluster")).toBeDefined();
+            expect(architectures.find(arch => arch.name === "Kubernetes Application")).toBeDefined();
             expect(architectures.find(arch => arch.name === "Virtual Machine")).toBeDefined();
         });
 


### PR DESCRIPTION
To align with the changes in https://github.com/pulumi/pulumi-hugo/pull/2183, this change updates the name of the Kubernetes architecture templates to "Kubernetes Cluster", and also adds a test for the Kubernetes Application templates. 