### PR TITLE
Fix commented reference to subnet

### DIFF
--- a/kubernetes-azure-csharp/Program.cs
+++ b/kubernetes-azure-csharp/Program.cs
@@ -84,7 +84,7 @@ return await Pulumi.Deployment.RunAsync(() =>
             Type = "VirtualMachineScaleSets",
             VmSize = nodeVmSize,
             // Change next line for additional node pools to distribute across subnets
-            // VnetSubnetID = subnet1.Id,
+            VnetSubnetID = subnet1.Id,
         },
 
         // Change authorizedIPRanges to limit access to API server


### PR DESCRIPTION
Uncomment the reference to subnet when creating the AKS node pool. Otherwise, the created AKS cluster does not use the virtual network and subnet created earlier in the template.

Fixes #443