### PR TITLE
Drop cloud references from template group names

### DIFF
--- a/metadata/dist/metadata.json
+++ b/metadata/dist/metadata.json
@@ -5,7 +5,7 @@
             "slug": "static-website",
             "groups": [
                 {
-                    "name": "AWS Static Website",
+                    "name": "Static Website",
                     "kind": "architecture",
                     "parent": "static-website",
                     "slug": "aws",
@@ -21,7 +21,7 @@
                     ]
                 },
                 {
-                    "name": "Azure Static Website",
+                    "name": "Static Website",
                     "kind": "architecture",
                     "parent": "static-website",
                     "slug": "azure",
@@ -37,7 +37,7 @@
                     ]
                 },
                 {
-                    "name": "Google Cloud Static Website",
+                    "name": "Static Website",
                     "kind": "architecture",
                     "parent": "static-website",
                     "slug": "gcp",
@@ -59,7 +59,7 @@
             "slug": "serverless-application",
             "groups": [
                 {
-                    "name": "AWS Serverless Application",
+                    "name": "Serverless Application",
                     "kind": "architecture",
                     "parent": "serverless-application",
                     "slug": "aws",
@@ -75,7 +75,7 @@
                     ]
                 },
                 {
-                    "name": "Azure Serverless Application",
+                    "name": "Serverless Application",
                     "kind": "architecture",
                     "parent": "serverless-application",
                     "slug": "azure",
@@ -91,7 +91,7 @@
                     ]
                 },
                 {
-                    "name": "Google Cloud Serverless Application",
+                    "name": "Serverless Application",
                     "kind": "architecture",
                     "parent": "serverless-application",
                     "slug": "gcp",
@@ -113,7 +113,7 @@
             "slug": "container-service",
             "groups": [
                 {
-                    "name": "Container Service on AWS",
+                    "name": "Container Service",
                     "kind": "architecture",
                     "parent": "container-service",
                     "slug": "aws",
@@ -129,7 +129,7 @@
                     ]
                 },
                 {
-                    "name": "Container Service on Azure",
+                    "name": "Container Service",
                     "kind": "architecture",
                     "parent": "container-service",
                     "slug": "azure",
@@ -144,7 +144,7 @@
                     ]
                 },
                 {
-                    "name": "Container Service on Google Cloud",
+                    "name": "Container Service",
                     "kind": "architecture",
                     "parent": "container-service",
                     "slug": "gcp",
@@ -165,7 +165,7 @@
             "slug": "virtual-machine",
             "groups": [
                 {
-                    "name": "Virtual Machine on AWS",
+                    "name": "Virtual Machine",
                     "kind": "architecture",
                     "parent": "virtual-machine",
                     "slug": "aws",
@@ -181,7 +181,7 @@
                     ]
                 },
                 {
-                    "name": "Virtual Machine on Azure",
+                    "name": "Virtual Machine",
                     "kind": "architecture",
                     "parent": "virtual-machine",
                     "slug": "azure",
@@ -197,7 +197,7 @@
                     ]
                 },
                 {
-                    "name": "Virtual Machine on Google Cloud",
+                    "name": "Virtual Machine",
                     "kind": "architecture",
                     "parent": "virtual-machine",
                     "slug": "gcp",
@@ -219,7 +219,7 @@
             "slug": "kubernetes",
             "groups": [
                 {
-                    "name": "Kubernetes Cluster on AWS",
+                    "name": "Kubernetes Cluster",
                     "kind": "architecture",
                     "parent": "kubernetes",
                     "slug": "aws",
@@ -235,7 +235,7 @@
                     ]
                 },
                 {
-                    "name": "Kubernetes Cluster on Azure",
+                    "name": "Kubernetes Cluster",
                     "kind": "architecture",
                     "parent": "kubernetes",
                     "slug": "azure",
@@ -251,7 +251,7 @@
                     ]
                 },
                 {
-                    "name": "Kubernetes Cluster on Google Cloud",
+                    "name": "Kubernetes Cluster",
                     "kind": "architecture",
                     "parent": "kubernetes",
                     "slug": "gcp",
@@ -273,7 +273,7 @@
             "slug": "kubernetes-application",
             "groups": [
                 {
-                    "name": "Helm Chart on Kubernetes",
+                    "name": "Helm Chart",
                     "kind": "architecture",
                     "parent": "kubernetes-application",
                     "slug": "helm-chart",
@@ -289,7 +289,7 @@
                     ]
                 },
                 {
-                    "name": "Web Application on Kubernetes",
+                    "name": "Web Application",
                     "kind": "architecture",
                     "parent": "kubernetes-application",
                     "slug": "web-application",

--- a/metadata/groups/container-service-aws.yaml
+++ b/metadata/groups/container-service-aws.yaml
@@ -1,4 +1,4 @@
-name: Container Service on AWS
+name: Container Service
 kind: architecture
 parent: container-service
 slug: aws

--- a/metadata/groups/container-service-azure.yaml
+++ b/metadata/groups/container-service-azure.yaml
@@ -1,4 +1,4 @@
-name: Container Service on Azure
+name: Container Service
 kind: architecture
 parent: container-service
 slug: azure

--- a/metadata/groups/container-service-gcp.yaml
+++ b/metadata/groups/container-service-gcp.yaml
@@ -1,4 +1,4 @@
-name: Container Service on Google Cloud
+name: Container Service
 kind: architecture
 parent: container-service
 slug: gcp

--- a/metadata/groups/helm-kubernetes.yaml
+++ b/metadata/groups/helm-kubernetes.yaml
@@ -1,4 +1,4 @@
-name: Helm Chart on Kubernetes
+name: Helm Chart
 kind: architecture
 parent: kubernetes-application
 slug: helm-chart

--- a/metadata/groups/kubernetes-aws.yaml
+++ b/metadata/groups/kubernetes-aws.yaml
@@ -1,4 +1,4 @@
-name: Kubernetes Cluster on AWS
+name: Kubernetes Cluster
 kind: architecture
 parent: kubernetes
 slug: aws

--- a/metadata/groups/kubernetes-azure.yaml
+++ b/metadata/groups/kubernetes-azure.yaml
@@ -1,4 +1,4 @@
-name: Kubernetes Cluster on Azure
+name: Kubernetes Cluster
 kind: architecture
 parent: kubernetes
 slug: azure

--- a/metadata/groups/kubernetes-gcp.yaml
+++ b/metadata/groups/kubernetes-gcp.yaml
@@ -1,4 +1,4 @@
-name: Kubernetes Cluster on Google Cloud
+name: Kubernetes Cluster
 kind: architecture
 parent: kubernetes
 slug: gcp

--- a/metadata/groups/serverless-application-aws.yaml
+++ b/metadata/groups/serverless-application-aws.yaml
@@ -1,4 +1,4 @@
-name: AWS Serverless Application
+name: Serverless Application
 kind: architecture
 parent: serverless-application
 slug: aws

--- a/metadata/groups/serverless-application-azure.yaml
+++ b/metadata/groups/serverless-application-azure.yaml
@@ -1,4 +1,4 @@
-name: Azure Serverless Application
+name: Serverless Application
 kind: architecture
 parent: serverless-application
 slug: azure

--- a/metadata/groups/serverless-application-gcp.yaml
+++ b/metadata/groups/serverless-application-gcp.yaml
@@ -1,4 +1,4 @@
-name: Google Cloud Serverless Application
+name: Serverless Application
 kind: architecture
 parent: serverless-application
 slug: gcp

--- a/metadata/groups/static-website-aws.yaml
+++ b/metadata/groups/static-website-aws.yaml
@@ -1,4 +1,4 @@
-name: AWS Static Website
+name: Static Website
 kind: architecture
 parent: static-website
 slug: aws

--- a/metadata/groups/static-website-azure.yaml
+++ b/metadata/groups/static-website-azure.yaml
@@ -1,4 +1,4 @@
-name: Azure Static Website
+name: Static Website
 kind: architecture
 parent: static-website
 slug: azure

--- a/metadata/groups/static-website-gcp.yaml
+++ b/metadata/groups/static-website-gcp.yaml
@@ -1,4 +1,4 @@
-name: Google Cloud Static Website
+name: Static Website
 kind: architecture
 parent: static-website
 slug: gcp

--- a/metadata/groups/virtual-machine-aws.yaml
+++ b/metadata/groups/virtual-machine-aws.yaml
@@ -1,4 +1,4 @@
-name: Virtual Machine on AWS
+name: Virtual Machine
 kind: architecture
 parent: virtual-machine
 slug: aws

--- a/metadata/groups/virtual-machine-azure.yaml
+++ b/metadata/groups/virtual-machine-azure.yaml
@@ -1,4 +1,4 @@
-name: Virtual Machine on Azure
+name: Virtual Machine
 kind: architecture
 parent: virtual-machine
 slug: azure

--- a/metadata/groups/virtual-machine-gcp.yaml
+++ b/metadata/groups/virtual-machine-gcp.yaml
@@ -1,4 +1,4 @@
-name: Virtual Machine on Google Cloud
+name: Virtual Machine
 kind: architecture
 parent: virtual-machine
 slug: gcp

--- a/metadata/groups/webapp-kubernetes.yaml
+++ b/metadata/groups/webapp-kubernetes.yaml
@@ -1,4 +1,4 @@
-name: Web Application on Kubernetes
+name: Web Application
 kind: architecture
 parent: kubernetes-application
 slug: web-application


### PR DESCRIPTION
These group names are more verbose than what's needed in the Service UI, so this change strips out the cloud names to make them a bit tidier. Additional context [in this thread](https://pulumi.slack.com/archives/C0289AASSG4/p1667500236565769).

This change will have no user-facing impact until the accompanying Service change (https://github.com/pulumi/pulumi-service/pull/11034) is merged.

Part of https://github.com/pulumi/pulumi-service/issues/11031.