### PR TITLE
Update examples to use config instead of configuration

### DIFF
--- a/container-aws-yaml/Pulumi.yaml
+++ b/container-aws-yaml/Pulumi.yaml
@@ -17,15 +17,15 @@ template:
       description: The amount of memory to allocate for the container
       default: 128
 
-configuration:
+config:
   containerPort:
-    type: Number
+    type: integer
     default: 80
   cpu:
-    type: Number
+    type: integer
     default: 512
   memory:
-    type: Number
+    type: integer
     default: 128
 
 resources:

--- a/container-aws-yaml/Pulumi.yaml.append
+++ b/container-aws-yaml/Pulumi.yaml.append
@@ -1,13 +1,13 @@
 
-configuration:
+config:
   containerPort:
-    type: Number
+    type: integer
     default: 80
   cpu:
-    type: Number
+    type: integer
     default: 512
   memory:
-    type: Number
+    type: integer
     default: 128
 
 resources:

--- a/helm-kubernetes-yaml/Pulumi.yaml
+++ b/helm-kubernetes-yaml/Pulumi.yaml
@@ -8,11 +8,11 @@ template:
       default: nginx-ingress
       description: The Kubernetes namespace to deploy into
 
-configuration:
+config:
   # Use this user-supplied value to create a Kubernetes namespace later
   k8sNamespace:
     default: nginx-ingress
-    type: String
+    type: string
 
 variables:
   # Define some labels that will be applied to resources

--- a/helm-kubernetes-yaml/Pulumi.yaml.append
+++ b/helm-kubernetes-yaml/Pulumi.yaml.append
@@ -1,8 +1,8 @@
-configuration:
+config:
   # Use this user-supplied value to create a Kubernetes namespace later
   k8sNamespace:
     default: nginx-ingress
-    type: String
+    type: string
 
 variables:
   # Define some labels that will be applied to resources

--- a/kubernetes-aws-yaml/Pulumi.yaml
+++ b/kubernetes-aws-yaml/Pulumi.yaml
@@ -22,21 +22,21 @@ template:
     vpcNetworkCidr:
       description: Network CIDR to use for new VPC
       default: 10.0.0.0/16
-configuration:
+config:
   minClusterSize:
-    type: Number
+    type: integer
     default: 3
   maxClusterSize:
-    type: Number
+    type: integer
     default: 6
   desiredClusterSize:
-    type: Number
+    type: integer
     default: 3
   eksNodeInstanceType:
-    type: String
+    type: string
     default: t2.medium
   vpcNetworkCidr:
-    type: String
+    type: string
     default: 10.0.0.0/16
 resources:
   # Create a VPC for the EKS cluster

--- a/kubernetes-aws-yaml/Pulumi.yaml.append
+++ b/kubernetes-aws-yaml/Pulumi.yaml.append
@@ -1,18 +1,18 @@
-configuration:
+config:
   minClusterSize:
-    type: Number
+    type: integer
     default: 3
   maxClusterSize:
-    type: Number
+    type: integer
     default: 6
   desiredClusterSize:
-    type: Number
+    type: integer
     default: 3
   eksNodeInstanceType:
-    type: String
+    type: string
     default: t2.medium
   vpcNetworkCidr:
-    type: String
+    type: string
     default: 10.0.0.0/16
 resources:
   # Create a VPC for the EKS cluster

--- a/kubernetes-azure-yaml/Pulumi.yaml
+++ b/kubernetes-azure-yaml/Pulumi.yaml
@@ -24,26 +24,26 @@ template:
     sshPubKey:
       description: Contents of the public key for SSH access to cluster nodes
 
-configuration:
+config:
   azure-native:location:
-    type: String
+    type: string
   numWorkerNodes:
-    type: Number
+    type: integer
     default: 3
   prefixForDns:
-    type: String
+    type: string
     default: pulumi
   kubernetesVersion:
-    type: String
+    type: string
     default: 1.24.3
   nodeVmSize:
-    type: String
+    type: string
     default: Standard_DS2_v2
   # The next two configuration values are required (no default can be provided)
   mgmtGroupId:
-    type: String
+    type: string
   sshPubKey:
-    type: String
+    type: string
 
 resources:
   # Create a new resource group

--- a/kubernetes-azure-yaml/Pulumi.yaml.append
+++ b/kubernetes-azure-yaml/Pulumi.yaml.append
@@ -1,23 +1,23 @@
-configuration:
+config:
   azure-native:location:
-    type: String
+    type: string
   numWorkerNodes:
-    type: Number
+    type: integer
     default: 3
   prefixForDns:
-    type: String
+    type: string
     default: pulumi
   kubernetesVersion:
-    type: String
+    type: string
     default: 1.24.3
   nodeVmSize:
-    type: String
+    type: string
     default: Standard_DS2_v2
   # The next two configuration values are required (no default can be provided)
   mgmtGroupId:
-    type: String
+    type: string
   sshPubKey:
-    type: String
+    type: string
 
 resources:
   # Create a new resource group

--- a/kubernetes-gcp-yaml/Pulumi.yaml
+++ b/kubernetes-gcp-yaml/Pulumi.yaml
@@ -13,14 +13,14 @@ template:
       default: 1
       description: The desired number of nodes PER ZONE in the nodepool
 
-configuration:
+config:
   gcp:project:
-    type: String
+    type: string
   gcp:region:
-    type: String
+    type: string
     default: us-central1
   nodesPerZone:
-    type: Number
+    type: integer
     default: 1
 
 resources:

--- a/kubernetes-gcp-yaml/Pulumi.yaml.append
+++ b/kubernetes-gcp-yaml/Pulumi.yaml.append
@@ -1,11 +1,11 @@
-configuration:
+config:
   gcp:project:
-    type: String
+    type: string
   gcp:region:
-    type: String
+    type: string
     default: us-central1
   nodesPerZone:
-    type: Number
+    type: integer
     default: 1
 
 resources:

--- a/serverless-azure-yaml/Pulumi.yaml
+++ b/serverless-azure-yaml/Pulumi.yaml
@@ -22,18 +22,18 @@ template:
       default: error.html
 
 # Import the program's configuration settings.
-configuration:
+config:
   sitePath:
-    type: String
+    type: string
     default: ./www
   appPath:
-    type: String
+    type: string
     default: ./app
   indexDocument:
-    type: String
+    type: string
     default: index.html
   errorDocument:
-    type: String
+    type: string
     default: error.html
 
 variables:

--- a/serverless-azure-yaml/Pulumi.yaml.append
+++ b/serverless-azure-yaml/Pulumi.yaml.append
@@ -1,17 +1,17 @@
 
 # Import the program's configuration settings.
-configuration:
+config:
   sitePath:
-    type: String
+    type: string
     default: ./www
   appPath:
-    type: String
+    type: string
     default: ./app
   indexDocument:
-    type: String
+    type: string
     default: index.html
   errorDocument:
-    type: String
+    type: string
     default: error.html
 
 variables:

--- a/serverless-gcp-yaml/Pulumi.yaml
+++ b/serverless-gcp-yaml/Pulumi.yaml
@@ -24,18 +24,18 @@ template:
       default: error.html
 
 # Import the program's configuration settings.
-configuration:
+config:
   sitePath:
-    type: String
+    type: string
     default: ./www
   appPath:
-    type: String
+    type: string
     default: ./app
   indexDocument:
-    type: String
+    type: string
     default: index.html
   errorDocument:
-    type: String
+    type: string
     default: error.html
 
 variables:

--- a/serverless-gcp-yaml/Pulumi.yaml.append
+++ b/serverless-gcp-yaml/Pulumi.yaml.append
@@ -1,17 +1,17 @@
 
 # Import the program's configuration settings.
-configuration:
+config:
   sitePath:
-    type: String
+    type: string
     default: ./www
   appPath:
-    type: String
+    type: string
     default: ./app
   indexDocument:
-    type: String
+    type: string
     default: index.html
   errorDocument:
-    type: String
+    type: string
     default: error.html
 
 variables:

--- a/static-website-aws-yaml/Pulumi.yaml
+++ b/static-website-aws-yaml/Pulumi.yaml
@@ -19,15 +19,15 @@ template:
       default: error.html
 
 # Import the program's configuration settings.
-configuration:
+config:
   path:
-    type: String
+    type: string
     default: ./www
   indexDocument:
-    type: String
+    type: string
     default: index.html
   errorDocument:
-    type: String
+    type: string
     default: error.html
 
 resources:

--- a/static-website-aws-yaml/Pulumi.yaml.append
+++ b/static-website-aws-yaml/Pulumi.yaml.append
@@ -1,14 +1,14 @@
 
 # Import the program's configuration settings.
-configuration:
+config:
   path:
-    type: String
+    type: string
     default: ./www
   indexDocument:
-    type: String
+    type: string
     default: index.html
   errorDocument:
-    type: String
+    type: string
     default: error.html
 
 resources:

--- a/static-website-azure-yaml/Pulumi.yaml
+++ b/static-website-azure-yaml/Pulumi.yaml
@@ -19,15 +19,15 @@ template:
       default: error.html
 
 # Import the program's configuration settings.
-configuration:
+config:
   path:
-    type: String
+    type: string
     default: ./www
   indexDocument:
-    type: String
+    type: string
     default: index.html
   errorDocument:
-    type: String
+    type: string
     default: error.html
 
 # Pull the hostname out of the storage-account endpoint.

--- a/static-website-azure-yaml/Pulumi.yaml.append
+++ b/static-website-azure-yaml/Pulumi.yaml.append
@@ -1,14 +1,14 @@
 
 # Import the program's configuration settings.
-configuration:
+config:
   path:
-    type: String
+    type: string
     default: ./www
   indexDocument:
-    type: String
+    type: string
     default: index.html
   errorDocument:
-    type: String
+    type: string
     default: error.html
 
 # Pull the hostname out of the storage-account endpoint.

--- a/static-website-gcp-yaml/Pulumi.yaml
+++ b/static-website-gcp-yaml/Pulumi.yaml
@@ -18,15 +18,15 @@ template:
       default: error.html
 
 # Import the program's configuration settings.
-configuration:
+config:
   path:
-    type: String
+    type: string
     default: ./www
   indexDocument:
-    type: String
+    type: string
     default: index.html
   errorDocument:
-    type: String
+    type: string
     default: error.html
 
 resources:

--- a/static-website-gcp-yaml/Pulumi.yaml.append
+++ b/static-website-gcp-yaml/Pulumi.yaml.append
@@ -1,14 +1,14 @@
 
 # Import the program's configuration settings.
-configuration:
+config:
   path:
-    type: String
+    type: string
     default: ./www
   indexDocument:
-    type: String
+    type: string
     default: index.html
   errorDocument:
-    type: String
+    type: string
     default: error.html
 
 resources:

--- a/vm-aws-yaml/Pulumi.yaml
+++ b/vm-aws-yaml/Pulumi.yaml
@@ -15,12 +15,12 @@ template:
             description: The network CIDR to use for the VPC
             default: 10.0.0.0/16
 
-configuration:
+config:
     instanceType:
-        type: String
+        type: string
         default: t3.micro
     vpcNetworkCidr:
-        type: String
+        type: string
         default: 10.0.0.0/16
 
 resources:  

--- a/vm-azure-yaml/Pulumi.yaml
+++ b/vm-azure-yaml/Pulumi.yaml
@@ -27,24 +27,24 @@ template:
       description: The public key data to use for SSH authentication
 
 # Import the program's configuration settings.
-configuration:
+config:
   adminUsername:
-    type: String
+    type: string
     default: pulumiuser
   vmName:
-    type: String
+    type: string
     default: my-server
   vmSize:
-    type: String
+    type: string
     default: Standard_A1_v2
   osImage:
-    type: String
+    type: string
     default: Debian:debian-11:11:latest
   servicePort:
-    type: String
+    type: string
     default: "80"
   sshPublicKey:
-    type: String
+    type: string
 
 variables:
   dnsName: ${vmName}-${random-string.result}

--- a/vm-azure-yaml/Pulumi.yaml.append
+++ b/vm-azure-yaml/Pulumi.yaml.append
@@ -1,23 +1,23 @@
 
 # Import the program's configuration settings.
-configuration:
+config:
   adminUsername:
-    type: String
+    type: string
     default: pulumiuser
   vmName:
-    type: String
+    type: string
     default: my-server
   vmSize:
-    type: String
+    type: string
     default: Standard_A1_v2
   osImage:
-    type: String
+    type: string
     default: Debian:debian-11:11:latest
   servicePort:
-    type: String
+    type: string
     default: "80"
   sshPublicKey:
-    type: String
+    type: string
 
 variables:
   dnsName: ${vmName}-${random-string.result}

--- a/vm-gcp-yaml/Pulumi.yaml
+++ b/vm-gcp-yaml/Pulumi.yaml
@@ -27,18 +27,18 @@ template:
       default: "80"
 
 # Import the program's configuration settings.
-configuration:
+config:
   machineType:
-    type: String
+    type: string
     default: f1-micro
   osImage:
-    type: String
+    type: string
     default: debian-11
   instanceTag:
-    type: String
+    type: string
     default: webserver
   servicePort:
-    type: String
+    type: string
     default: "80"
 
 variables:

--- a/vm-gcp-yaml/Pulumi.yaml.append
+++ b/vm-gcp-yaml/Pulumi.yaml.append
@@ -1,17 +1,17 @@
 
 # Import the program's configuration settings.
-configuration:
+config:
   machineType:
-    type: String
+    type: string
     default: f1-micro
   osImage:
-    type: String
+    type: string
     default: debian-11
   instanceTag:
-    type: String
+    type: string
     default: webserver
   servicePort:
-    type: String
+    type: string
     default: "80"
 
 variables:

--- a/webapp-kubernetes-yaml/Pulumi.yaml
+++ b/webapp-kubernetes-yaml/Pulumi.yaml
@@ -11,13 +11,13 @@ template:
       default: 1
       description: The number of replicas to deploy
 
-configuration:
+config:
   k8sNamespace:
     default: default
-    type: String
+    type: string
   numReplicas:
     default: 1
-    type: Number
+    type: integer
 
 variables:
   appLabels:

--- a/webapp-kubernetes-yaml/Pulumi.yaml.append
+++ b/webapp-kubernetes-yaml/Pulumi.yaml.append
@@ -1,10 +1,10 @@
-configuration:
+config:
   k8sNamespace:
     default: default
-    type: String
+    type: string
   numReplicas:
     default: 1
-    type: Number
+    type: integer
 
 variables:
   appLabels:

--- a/yaml/Pulumi.yaml
+++ b/yaml/Pulumi.yaml
@@ -4,7 +4,7 @@ runtime: yaml
 template:
   description: A minimal Pulumi YAML program
 
-configuration: {}
+config: {}
 variables:     {}
 resources:     {}
 outputs:       {}

--- a/yaml/Pulumi.yaml.append
+++ b/yaml/Pulumi.yaml.append
@@ -1,5 +1,5 @@
 
-configuration: {}
+config: {}
 variables:     {}
 resources:     {}
 outputs:       {}


### PR DESCRIPTION
pulumi-yaml `configuration` is being deprecated in favor of the project-level `config` block 
Fixes #453 