### PR TITLE
Skip benchmarks to save disk space on container

### DIFF
--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -15,7 +15,7 @@ env:
   GOOGLE_PROJECT: pulumi-ci-gcp-provider
   GOOGLE_PROJECT_NUMBER: 895284651812
   LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
-  SKIPPED_BENCHMARKS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,static-website,visualbasic,serverless,container-aws"
+  SKIPPED_BENCHMARKS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,static-website,visualbasic,serverless,container-aws,container-azure,container-gcp,vm-aws,vm-azure,vm-gcp"
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_TRACING_NO_PAYLOADS: 1
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
https://github.com/pulumi/templates/actions/runs/3475152250/jobs/5809065821 an example of running out of disk space. Skipping these for now should speed up the job and save disk space. 