### PR TITLE
Revert "Update examples to use config instead of configuration"

### DIFF
--- a/container-aws-yaml/Pulumi.yaml
+++ b/container-aws-yaml/Pulumi.yaml
@@ -17,15 +17,15 @@ template:
       description: The amount of memory to allocate for the container
       default: 128
 
-config:
+configuration:
   containerPort:
-    type: integer
+    type: Number
     default: 80
   cpu:
-    type: integer
+    type: Number
     default: 512
   memory:
-    type: integer
+    type: Number
     default: 128
 
 resources:

--- a/container-aws-yaml/Pulumi.yaml.append
+++ b/container-aws-yaml/Pulumi.yaml.append
@@ -1,13 +1,13 @@
 
-config:
+configuration:
   containerPort:
-    type: integer
+    type: Number
     default: 80
   cpu:
-    type: integer
+    type: Number
     default: 512
   memory:
-    type: integer
+    type: Number
     default: 128
 
 resources:

--- a/helm-kubernetes-yaml/Pulumi.yaml
+++ b/helm-kubernetes-yaml/Pulumi.yaml
@@ -8,11 +8,11 @@ template:
       default: nginx-ingress
       description: The Kubernetes namespace to deploy into
 
-config:
+configuration:
   # Use this user-supplied value to create a Kubernetes namespace later
   k8sNamespace:
     default: nginx-ingress
-    type: string
+    type: String
 
 variables:
   # Define some labels that will be applied to resources

--- a/helm-kubernetes-yaml/Pulumi.yaml.append
+++ b/helm-kubernetes-yaml/Pulumi.yaml.append
@@ -1,8 +1,8 @@
-config:
+configuration:
   # Use this user-supplied value to create a Kubernetes namespace later
   k8sNamespace:
     default: nginx-ingress
-    type: string
+    type: String
 
 variables:
   # Define some labels that will be applied to resources

--- a/kubernetes-aws-yaml/Pulumi.yaml
+++ b/kubernetes-aws-yaml/Pulumi.yaml
@@ -22,21 +22,21 @@ template:
     vpcNetworkCidr:
       description: Network CIDR to use for new VPC
       default: 10.0.0.0/16
-config:
+configuration:
   minClusterSize:
-    type: integer
+    type: Number
     default: 3
   maxClusterSize:
-    type: integer
+    type: Number
     default: 6
   desiredClusterSize:
-    type: integer
+    type: Number
     default: 3
   eksNodeInstanceType:
-    type: string
+    type: String
     default: t2.medium
   vpcNetworkCidr:
-    type: string
+    type: String
     default: 10.0.0.0/16
 resources:
   # Create a VPC for the EKS cluster

--- a/kubernetes-aws-yaml/Pulumi.yaml.append
+++ b/kubernetes-aws-yaml/Pulumi.yaml.append
@@ -1,18 +1,18 @@
-config:
+configuration:
   minClusterSize:
-    type: integer
+    type: Number
     default: 3
   maxClusterSize:
-    type: integer
+    type: Number
     default: 6
   desiredClusterSize:
-    type: integer
+    type: Number
     default: 3
   eksNodeInstanceType:
-    type: string
+    type: String
     default: t2.medium
   vpcNetworkCidr:
-    type: string
+    type: String
     default: 10.0.0.0/16
 resources:
   # Create a VPC for the EKS cluster

--- a/kubernetes-azure-yaml/Pulumi.yaml
+++ b/kubernetes-azure-yaml/Pulumi.yaml
@@ -24,26 +24,26 @@ template:
     sshPubKey:
       description: Contents of the public key for SSH access to cluster nodes
 
-config:
+configuration:
   azure-native:location:
-    type: string
+    type: String
   numWorkerNodes:
-    type: integer
+    type: Number
     default: 3
   prefixForDns:
-    type: string
+    type: String
     default: pulumi
   kubernetesVersion:
-    type: string
+    type: String
     default: 1.24.3
   nodeVmSize:
-    type: string
+    type: String
     default: Standard_DS2_v2
   # The next two configuration values are required (no default can be provided)
   mgmtGroupId:
-    type: string
+    type: String
   sshPubKey:
-    type: string
+    type: String
 
 resources:
   # Create a new resource group

--- a/kubernetes-azure-yaml/Pulumi.yaml.append
+++ b/kubernetes-azure-yaml/Pulumi.yaml.append
@@ -1,23 +1,23 @@
-config:
+configuration:
   azure-native:location:
-    type: string
+    type: String
   numWorkerNodes:
-    type: integer
+    type: Number
     default: 3
   prefixForDns:
-    type: string
+    type: String
     default: pulumi
   kubernetesVersion:
-    type: string
+    type: String
     default: 1.24.3
   nodeVmSize:
-    type: string
+    type: String
     default: Standard_DS2_v2
   # The next two configuration values are required (no default can be provided)
   mgmtGroupId:
-    type: string
+    type: String
   sshPubKey:
-    type: string
+    type: String
 
 resources:
   # Create a new resource group

--- a/kubernetes-gcp-yaml/Pulumi.yaml
+++ b/kubernetes-gcp-yaml/Pulumi.yaml
@@ -13,14 +13,14 @@ template:
       default: 1
       description: The desired number of nodes PER ZONE in the nodepool
 
-config:
+configuration:
   gcp:project:
-    type: string
+    type: String
   gcp:region:
-    type: string
+    type: String
     default: us-central1
   nodesPerZone:
-    type: integer
+    type: Number
     default: 1
 
 resources:

--- a/kubernetes-gcp-yaml/Pulumi.yaml.append
+++ b/kubernetes-gcp-yaml/Pulumi.yaml.append
@@ -1,11 +1,11 @@
-config:
+configuration:
   gcp:project:
-    type: string
+    type: String
   gcp:region:
-    type: string
+    type: String
     default: us-central1
   nodesPerZone:
-    type: integer
+    type: Number
     default: 1
 
 resources:

--- a/serverless-azure-yaml/Pulumi.yaml
+++ b/serverless-azure-yaml/Pulumi.yaml
@@ -22,18 +22,18 @@ template:
       default: error.html
 
 # Import the program's configuration settings.
-config:
+configuration:
   sitePath:
-    type: string
+    type: String
     default: ./www
   appPath:
-    type: string
+    type: String
     default: ./app
   indexDocument:
-    type: string
+    type: String
     default: index.html
   errorDocument:
-    type: string
+    type: String
     default: error.html
 
 variables:

--- a/serverless-azure-yaml/Pulumi.yaml.append
+++ b/serverless-azure-yaml/Pulumi.yaml.append
@@ -1,17 +1,17 @@
 
 # Import the program's configuration settings.
-config:
+configuration:
   sitePath:
-    type: string
+    type: String
     default: ./www
   appPath:
-    type: string
+    type: String
     default: ./app
   indexDocument:
-    type: string
+    type: String
     default: index.html
   errorDocument:
-    type: string
+    type: String
     default: error.html
 
 variables:

--- a/serverless-gcp-yaml/Pulumi.yaml
+++ b/serverless-gcp-yaml/Pulumi.yaml
@@ -24,18 +24,18 @@ template:
       default: error.html
 
 # Import the program's configuration settings.
-config:
+configuration:
   sitePath:
-    type: string
+    type: String
     default: ./www
   appPath:
-    type: string
+    type: String
     default: ./app
   indexDocument:
-    type: string
+    type: String
     default: index.html
   errorDocument:
-    type: string
+    type: String
     default: error.html
 
 variables:

--- a/serverless-gcp-yaml/Pulumi.yaml.append
+++ b/serverless-gcp-yaml/Pulumi.yaml.append
@@ -1,17 +1,17 @@
 
 # Import the program's configuration settings.
-config:
+configuration:
   sitePath:
-    type: string
+    type: String
     default: ./www
   appPath:
-    type: string
+    type: String
     default: ./app
   indexDocument:
-    type: string
+    type: String
     default: index.html
   errorDocument:
-    type: string
+    type: String
     default: error.html
 
 variables:

--- a/static-website-aws-yaml/Pulumi.yaml
+++ b/static-website-aws-yaml/Pulumi.yaml
@@ -19,15 +19,15 @@ template:
       default: error.html
 
 # Import the program's configuration settings.
-config:
+configuration:
   path:
-    type: string
+    type: String
     default: ./www
   indexDocument:
-    type: string
+    type: String
     default: index.html
   errorDocument:
-    type: string
+    type: String
     default: error.html
 
 resources:

--- a/static-website-aws-yaml/Pulumi.yaml.append
+++ b/static-website-aws-yaml/Pulumi.yaml.append
@@ -1,14 +1,14 @@
 
 # Import the program's configuration settings.
-config:
+configuration:
   path:
-    type: string
+    type: String
     default: ./www
   indexDocument:
-    type: string
+    type: String
     default: index.html
   errorDocument:
-    type: string
+    type: String
     default: error.html
 
 resources:

--- a/static-website-azure-yaml/Pulumi.yaml
+++ b/static-website-azure-yaml/Pulumi.yaml
@@ -19,15 +19,15 @@ template:
       default: error.html
 
 # Import the program's configuration settings.
-config:
+configuration:
   path:
-    type: string
+    type: String
     default: ./www
   indexDocument:
-    type: string
+    type: String
     default: index.html
   errorDocument:
-    type: string
+    type: String
     default: error.html
 
 # Pull the hostname out of the storage-account endpoint.

--- a/static-website-azure-yaml/Pulumi.yaml.append
+++ b/static-website-azure-yaml/Pulumi.yaml.append
@@ -1,14 +1,14 @@
 
 # Import the program's configuration settings.
-config:
+configuration:
   path:
-    type: string
+    type: String
     default: ./www
   indexDocument:
-    type: string
+    type: String
     default: index.html
   errorDocument:
-    type: string
+    type: String
     default: error.html
 
 # Pull the hostname out of the storage-account endpoint.

--- a/static-website-gcp-yaml/Pulumi.yaml
+++ b/static-website-gcp-yaml/Pulumi.yaml
@@ -18,15 +18,15 @@ template:
       default: error.html
 
 # Import the program's configuration settings.
-config:
+configuration:
   path:
-    type: string
+    type: String
     default: ./www
   indexDocument:
-    type: string
+    type: String
     default: index.html
   errorDocument:
-    type: string
+    type: String
     default: error.html
 
 resources:

--- a/static-website-gcp-yaml/Pulumi.yaml.append
+++ b/static-website-gcp-yaml/Pulumi.yaml.append
@@ -1,14 +1,14 @@
 
 # Import the program's configuration settings.
-config:
+configuration:
   path:
-    type: string
+    type: String
     default: ./www
   indexDocument:
-    type: string
+    type: String
     default: index.html
   errorDocument:
-    type: string
+    type: String
     default: error.html
 
 resources:

--- a/vm-aws-yaml/Pulumi.yaml
+++ b/vm-aws-yaml/Pulumi.yaml
@@ -15,12 +15,12 @@ template:
             description: The network CIDR to use for the VPC
             default: 10.0.0.0/16
 
-config:
+configuration:
     instanceType:
-        type: string
+        type: String
         default: t3.micro
     vpcNetworkCidr:
-        type: string
+        type: String
         default: 10.0.0.0/16
 
 resources:  

--- a/vm-azure-yaml/Pulumi.yaml
+++ b/vm-azure-yaml/Pulumi.yaml
@@ -27,24 +27,24 @@ template:
       description: The public key data to use for SSH authentication
 
 # Import the program's configuration settings.
-config:
+configuration:
   adminUsername:
-    type: string
+    type: String
     default: pulumiuser
   vmName:
-    type: string
+    type: String
     default: my-server
   vmSize:
-    type: string
+    type: String
     default: Standard_A1_v2
   osImage:
-    type: string
+    type: String
     default: Debian:debian-11:11:latest
   servicePort:
-    type: string
+    type: String
     default: "80"
   sshPublicKey:
-    type: string
+    type: String
 
 variables:
   dnsName: ${vmName}-${random-string.result}

--- a/vm-azure-yaml/Pulumi.yaml.append
+++ b/vm-azure-yaml/Pulumi.yaml.append
@@ -1,23 +1,23 @@
 
 # Import the program's configuration settings.
-config:
+configuration:
   adminUsername:
-    type: string
+    type: String
     default: pulumiuser
   vmName:
-    type: string
+    type: String
     default: my-server
   vmSize:
-    type: string
+    type: String
     default: Standard_A1_v2
   osImage:
-    type: string
+    type: String
     default: Debian:debian-11:11:latest
   servicePort:
-    type: string
+    type: String
     default: "80"
   sshPublicKey:
-    type: string
+    type: String
 
 variables:
   dnsName: ${vmName}-${random-string.result}

--- a/vm-gcp-yaml/Pulumi.yaml
+++ b/vm-gcp-yaml/Pulumi.yaml
@@ -27,18 +27,18 @@ template:
       default: "80"
 
 # Import the program's configuration settings.
-config:
+configuration:
   machineType:
-    type: string
+    type: String
     default: f1-micro
   osImage:
-    type: string
+    type: String
     default: debian-11
   instanceTag:
-    type: string
+    type: String
     default: webserver
   servicePort:
-    type: string
+    type: String
     default: "80"
 
 variables:

--- a/vm-gcp-yaml/Pulumi.yaml.append
+++ b/vm-gcp-yaml/Pulumi.yaml.append
@@ -1,17 +1,17 @@
 
 # Import the program's configuration settings.
-config:
+configuration:
   machineType:
-    type: string
+    type: String
     default: f1-micro
   osImage:
-    type: string
+    type: String
     default: debian-11
   instanceTag:
-    type: string
+    type: String
     default: webserver
   servicePort:
-    type: string
+    type: String
     default: "80"
 
 variables:

--- a/webapp-kubernetes-yaml/Pulumi.yaml
+++ b/webapp-kubernetes-yaml/Pulumi.yaml
@@ -11,13 +11,13 @@ template:
       default: 1
       description: The number of replicas to deploy
 
-config:
+configuration:
   k8sNamespace:
     default: default
-    type: string
+    type: String
   numReplicas:
     default: 1
-    type: integer
+    type: Number
 
 variables:
   appLabels:

--- a/webapp-kubernetes-yaml/Pulumi.yaml.append
+++ b/webapp-kubernetes-yaml/Pulumi.yaml.append
@@ -1,10 +1,10 @@
-config:
+configuration:
   k8sNamespace:
     default: default
-    type: string
+    type: String
   numReplicas:
     default: 1
-    type: integer
+    type: Number
 
 variables:
   appLabels:

--- a/yaml/Pulumi.yaml
+++ b/yaml/Pulumi.yaml
@@ -4,7 +4,7 @@ runtime: yaml
 template:
   description: A minimal Pulumi YAML program
 
-config: {}
+configuration: {}
 variables:     {}
 resources:     {}
 outputs:       {}

--- a/yaml/Pulumi.yaml.append
+++ b/yaml/Pulumi.yaml.append
@@ -1,5 +1,5 @@
 
-config: {}
+configuration: {}
 variables:     {}
 resources:     {}
 outputs:       {}


### PR DESCRIPTION
Reverts pulumi/templates#454

Test failures in `pulumi/pulumi` (https://github.com/pulumi/pulumi/actions/runs/3525688587/jobs/5912834569#step:36:112) likely due to change from `configuration` to `config` key in YAML templates.

Fixes https://github.com/pulumi/pulumi/issues/11433