### PR TITLE
Unpin .NET dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ go.sum
 Pulumi.*.yaml
 node_modules
 .vscode
+[Bb]in/
+[Oo]bj/

--- a/container-azure-csharp/${PROJECT}.csproj
+++ b/container-azure-csharp/${PROJECT}.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
         <PackageReference Include="Pulumi" Version="3.*" />
         <PackageReference Include="Pulumi.AzureNative" Version="1.*" />
-        <PackageReference Include="Pulumi.Docker" Version="3.4.1" />
-        <PackageReference Include="Pulumi.Random" Version="4.8.2" />
+        <PackageReference Include="Pulumi.Docker" Version="3.*" />
+        <PackageReference Include="Pulumi.Random" Version="4.*" />
     </ItemGroup>
 </Project>

--- a/container-gcp-csharp/${PROJECT}.csproj
+++ b/container-gcp-csharp/${PROJECT}.csproj
@@ -11,6 +11,6 @@
     <ItemGroup>
         <PackageReference Include="Pulumi" Version="3.*" />
         <PackageReference Include="Pulumi.Gcp" Version="6.*" />
-        <PackageReference Include="Pulumi.Docker" Version="3.4.*" />
+        <PackageReference Include="Pulumi.Docker" Version="3.*" />
     </ItemGroup>
 </Project>

--- a/helm-kubernetes-csharp/${PROJECT}.csproj
+++ b/helm-kubernetes-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Kubernetes" Version="3.21.4" />
+		<PackageReference Include="Pulumi.Kubernetes" Version="3.*" />
 	</ItemGroup>
 
 </Project>

--- a/kubernetes-gcp-csharp/${PROJECT}.csproj
+++ b/kubernetes-gcp-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Gcp" Version="6.39.0" />
+		<PackageReference Include="Pulumi.Gcp" Version="6.*" />
 	</ItemGroup>
 
 </Project>

--- a/serverless-aws-csharp/${PROJECT}.csproj
+++ b/serverless-aws-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Aws" Version="5.13.0" />
+		<PackageReference Include="Pulumi.Aws" Version="5.*" />
 		<PackageReference Include="Pulumi.AwsApiGateway" Version="*" />
 	</ItemGroup>
 

--- a/serverless-azure-csharp/${PROJECT}.csproj
+++ b/serverless-azure-csharp/${PROJECT}.csproj
@@ -12,8 +12,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.AzureNative" Version="1.78.0" />
-		<PackageReference Include="Pulumi.Command" Version="4.5.0" />
+		<PackageReference Include="Pulumi.AzureNative" Version="1.*" />
+		<PackageReference Include="Pulumi.Command" Version="4.*" />
 		<PackageReference Include="Pulumi.SyncedFolder" Version="*" />
 	</ItemGroup>
 </Project>

--- a/serverless-gcp-csharp/${PROJECT}.csproj
+++ b/serverless-gcp-csharp/${PROJECT}.csproj
@@ -11,6 +11,6 @@
     <ItemGroup>
         <PackageReference Include="Pulumi" Version="3.*" />
         <PackageReference Include="Pulumi.Gcp" Version="6.*" />
-        <PackageReference Include="Pulumi.SyncedFolder" Version="0.0.8" />
+        <PackageReference Include="Pulumi.SyncedFolder" Version="*" />
     </ItemGroup>
 </Project>

--- a/static-website-aws-csharp/${PROJECT}.csproj
+++ b/static-website-aws-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Pulumi" Version="3.*" />
-        <PackageReference Include="Pulumi.Aws" Version="5.13.0" />
+        <PackageReference Include="Pulumi.Aws" Version="5.*" />
         <PackageReference Include="Pulumi.SyncedFolder" Version="*" />
     </ItemGroup>
 

--- a/static-website-azure-csharp/${PROJECT}.csproj
+++ b/static-website-azure-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Pulumi" Version="3.*" />
-        <PackageReference Include="Pulumi.AzureNative" Version="1.71.0" />
+        <PackageReference Include="Pulumi.AzureNative" Version="1.*" />
         <PackageReference Include="Pulumi.SyncedFolder" Version="*" />
     </ItemGroup>
 

--- a/static-website-gcp-csharp/${PROJECT}.csproj
+++ b/static-website-gcp-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Pulumi" Version="3.*" />
-        <PackageReference Include="Pulumi.Gcp" Version="6.35.0" />
+        <PackageReference Include="Pulumi.Gcp" Version="6.*" />
         <PackageReference Include="Pulumi.SyncedFolder" Version="*" />
     </ItemGroup>
 

--- a/vm-aws-csharp/${PROJECT}.csproj
+++ b/vm-aws-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Aws" Version="5.18.0" />
+		<PackageReference Include="Pulumi.Aws" Version="5.*" />
 	</ItemGroup>
 
 </Project>

--- a/vm-azure-csharp/${PROJECT}.csproj
+++ b/vm-azure-csharp/${PROJECT}.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.AzureNative" Version="1.*" />
-    <PackageReference Include="Pulumi.Random" Version="4.8.2" />
+    <PackageReference Include="Pulumi.Random" Version="4.*" />
   </ItemGroup>
 
 </Project>

--- a/webapp-kubernetes-csharp/${PROJECT}.csproj
+++ b/webapp-kubernetes-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Kubernetes" Version="3.21.4" />
+		<PackageReference Include="Pulumi.Kubernetes" Version="3.*" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Allows programs to pick up minor and patch versions of Pulumi dependencies. (One of these templates, `serverless-aws-csharp`, is currently failing  because it's pinned to `Aws = 5.13.0`, but `AwsApiGateway` is trying to upgrade it to `>= 5.21.1`.)

```
...
my-serverless-app.csproj : error NU1605: Detected package downgrade: Pulumi.Aws from 5.21.1 to 5.13.0. Reference the package directly from the project to select a different version.
```
 
Fixes #469.