### PR TITLE
Fix YAML template for Kubernetes on GCP

### DIFF
--- a/kubernetes-gcp-yaml/Pulumi.yaml
+++ b/kubernetes-gcp-yaml/Pulumi.yaml
@@ -14,10 +14,6 @@ template:
       description: The desired number of nodes PER ZONE in the nodepool
 
 config:
-  gcp:project:
-    value: changeme
-  gcp:region:
-    value: us-central1
   nodesPerZone:
     type: integer
     default: 1

--- a/kubernetes-gcp-yaml/Pulumi.yaml
+++ b/kubernetes-gcp-yaml/Pulumi.yaml
@@ -15,10 +15,9 @@ template:
 
 config:
   gcp:project:
-    type: string
+    value: changeme
   gcp:region:
-    type: string
-    default: us-central1
+    value: us-central1
   nodesPerZone:
     type: integer
     default: 1

--- a/kubernetes-gcp-yaml/Pulumi.yaml.append
+++ b/kubernetes-gcp-yaml/Pulumi.yaml.append
@@ -1,8 +1,4 @@
 config:
-  gcp:project:
-    value: changeme
-  gcp:region:
-    value: us-central1
   nodesPerZone:
     type: integer
     default: 1

--- a/kubernetes-gcp-yaml/Pulumi.yaml.append
+++ b/kubernetes-gcp-yaml/Pulumi.yaml.append
@@ -1,9 +1,8 @@
 config:
   gcp:project:
-    type: string
+    value: changeme
   gcp:region:
-    type: string
-    default: us-central1
+    value: us-central1
   nodesPerZone:
     type: integer
     default: 1


### PR DESCRIPTION
This PR fixes issues with the YAML template for Kubernetes on GCP, which was affected by the issue described in #477. No other templates were identified as being affected by #477.

This PR fixes #477.