### PR TITLE
fix(arm): default to linux/amd64

### DIFF
--- a/container-gcp-typescript/index.ts
+++ b/container-gcp-typescript/index.ts
@@ -21,6 +21,9 @@ const image = new docker.Image("image", {
     imageName: `gcr.io/${project}/${imageName}`,
     build: {
         context: appPath,
+        env: {
+            DOCKER_DEFAULT_PLATFORM: "linux/amd64", // https://github.com/pulumi/pulumi-docker/issues/296#issuecomment-1030094518
+        },
     },
 });
 

--- a/container-gcp-typescript/index.ts
+++ b/container-gcp-typescript/index.ts
@@ -22,7 +22,9 @@ const image = new docker.Image("image", {
     build: {
         context: appPath,
         env: {
-            DOCKER_DEFAULT_PLATFORM: "linux/amd64", // https://github.com/pulumi/pulumi-docker/issues/296#issuecomment-1030094518
+            // Cloud Run currently requires x86_64 images
+            // https://cloud.google.com/run/docs/container-contract#languages
+            DOCKER_DEFAULT_PLATFORM: "linux/amd64",
         },
     },
 });


### PR DESCRIPTION
Locally on my mac m1 (arm) I had issue on gcp running the image:

> The user-provided container failed to start and listen on the port defined provided by the PORT=8080 environment variable. Logs for this revision might contain more information.

```
Diagnostics:
  gcp:cloudrun:Service (service):
    error: 1 error occurred:
        * updating urn:pulumi:dev::pulumi-test01::gcp:cloudrun/service:Service::service: 1 error occurred:
        * resource is in failed state "Ready:False", message: Revision 'service-XXXXXXX-XXXXX' is not ready and cannot serve traffic. The user-provided container failed to start and listen on the port defined provided by the PORT=8080 environment variable. Logs for this revision might contain more information.
```

Reading at [the doc](https://cloud.google.com/run/docs/troubleshooting#container-failed-to-start:~:text=Verify%20that%20your%20container%20image%20is%20compiled%20for%2064%2Dbit%20Linux%20as%20required%20by%20the%20container%20runtime%20contract.) pointed in the log message:

> If you build your container image on a ARM based machine, then it might not work as expected when used with Cloud Run.

---

Fortunately, I found a solution, I'm submitting in this PR:

https://github.com/pulumi/templates/blob/a6429ce604c6e10b37d1f8e232566f998f0b0cd9/container-gcp-typescript/index.ts#L24-L26

- https://github.com/pulumi/pulumi-docker/issues/296#issuecomment-1030094518
- https://www.pulumi.com/registry/packages/docker/api-docs/image/#env_nodejs