### PR TITLE
Skip updates, {vm,kubernetes}-azure-yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
   GOOGLE_PROJECT: pulumi-ci-gcp-provider
   GOOGLE_PROJECT_NUMBER: 895284651812
   LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
-  SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops"
+  SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container,vm-azure-yaml,kubernetes-azure-yaml,github-go"
   PULUMI_API: https://api.pulumi-staging.io
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_VERSION: ${{ github.event.client_payload.ref }}
@@ -125,14 +125,11 @@ jobs:
         env:
           PULUMI_PYTHON_CMD: python
           TESTPARALLELISM: 3
-          SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container"
       - if: contains(matrix.platform, 'macos')
         name: Running macOS tests
         run: |
           set -euo pipefail
           cd tests && go test -v -json -count=1 -cover -timeout 6h -parallel ${{ env.TESTPARALLELISM }} . 2>&1 | gotestfmt
-        env:
-          SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container"
       - if: contains(matrix.platform, 'ubuntu')
         name: Running Linux tests
         run: |

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,7 +15,7 @@ env:
   GOOGLE_PROJECT: pulumi-ci-gcp-provider
   GOOGLE_PROJECT_NUMBER: 895284651812
   LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
-  SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops"
+  SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container,vm-azure-yaml,kubernetes-azure-yaml,github-go"
   PULUMI_API: https://api.pulumi-staging.io
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   ARM_CLIENT_ID:  ${{ secrets.ARM_CLIENT_ID }}

--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -17,7 +17,7 @@ env:
   GOOGLE_PROJECT: pulumi-ci-gcp-provider
   GOOGLE_PROJECT_NUMBER: 895284651812
   LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
-  SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops"
+  SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container,vm-azure-yaml,kubernetes-azure-yaml,github-go"
   PULUMI_API: https://api.pulumi-staging.io
   ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
@@ -130,14 +130,11 @@ jobs:
         env:
           PULUMI_PYTHON_CMD: python
           TESTPARALLELISM: 3
-          SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container"
       - if: contains(matrix.platform, 'macOS')
         name: Running macOS tests
         run: |
           set -euo pipefail
           cd tests && go test -v -json -count=1 -cover -timeout 6h -parallel ${{ env.TESTPARALLELISM }} . 2>&1 | gotestfmt
-        env:
-          SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container"
       - if: contains(matrix.platform, 'ubuntu')
         name: Running Linux tests
         run: |

--- a/generator/mod-templates/github-template.txt
+++ b/generator/mod-templates/github-template.txt
@@ -6,4 +6,3 @@ require (
 	github.com/pulumi/pulumi-github/sdk/v4 ${VERSION}
 	github.com/pulumi/pulumi/sdk/v3 ${PULUMI_VERSION}
 )
-

--- a/github-go/go.mod
+++ b/github-go/go.mod
@@ -6,4 +6,3 @@ require (
 	github.com/pulumi/pulumi-github/sdk/v4 v5.1.0
 	github.com/pulumi/pulumi/sdk/v3 v3.51.0
 )
-

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -40,6 +40,10 @@ func TestTemplates(t *testing.T) {
 				UseAutomaticVirtualEnv: true,
 				PrepareProject:         testutils.PrepareProject(t, e),
 				RequireService:         true,
+
+				// Skip updates to allow tests to complete more reliably.
+				// See https://github.com/pulumi/devrel-team/issues/464 for details.
+				SkipUpdate: true,
 			})
 		})
 	}


### PR DESCRIPTION
As a follow-up to https://github.com/pulumi/devrel-team/issues/464, this change skips running full updates for all templates, relying instead on successful previews, and adds `vm-azure-yaml` and `kubernetes-azure-yaml` to the list of skipped tests.

Doesn't represent the ideal state for sure, but given the state we're in now, we think this is an acceptable trade-off to get back to reliably passing while we explore alternative ways to run full deployments for some or all templates.

Note that this change also skips testing `github-go` (temporarily) due to https://github.com/pulumi/templates/issues/481. I'll remove it from the list once that issue's fixed.

Fixes https://github.com/pulumi/devrel-team/issues/487.