### PR TITLE
Use GITHUB_TOKEN in curl requests, run generate-go-mod.sh

### DIFF
--- a/aws-go/go.mod
+++ b/aws-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.17
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v5 v5.25.0
+	github.com/pulumi/pulumi-aws/sdk/v5 v5.27.0
 	github.com/pulumi/pulumi/sdk/v3 v3.51.0
 )

--- a/azure-classic-go/go.mod
+++ b/azure-classic-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.17
 
 require (
-	github.com/pulumi/pulumi-azure/sdk/v5 v5.28.0
+	github.com/pulumi/pulumi-azure/sdk/v5 v5.30.0
 	github.com/pulumi/pulumi/sdk/v3 v3.51.0
 )

--- a/azure-go/go.mod
+++ b/azure-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.17
 
 require (
-	github.com/pulumi/pulumi-azure-native/sdk v1.90.0
+	github.com/pulumi/pulumi-azure-native/sdk v1.91.0
 	github.com/pulumi/pulumi/sdk/v3 v3.51.0
 )

--- a/civo-go/go.mod
+++ b/civo-go/go.mod
@@ -3,7 +3,7 @@ module ${PROJECT}
 go 1.17
 
 require (
-	github.com/pulumi/pulumi-civo/sdk/v2 v2.3.0
+	github.com/pulumi/pulumi-civo/sdk/v2 v2.3.1
 	github.com/pulumi/pulumi/sdk/v3 v3.51.0
 )
 

--- a/equinix-metal-go/go.mod
+++ b/equinix-metal-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.17
 
 require (
-	github.com/pulumi/pulumi-equinix-metal/sdk/v2 v3.2.1
+	github.com/pulumi/pulumi-equinix-metal/sdk/v3 v3.2.1
 	github.com/pulumi/pulumi/sdk/v3 v3.51.0
 )

--- a/equinix-metal-go/main.go
+++ b/equinix-metal-go/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	metal "github.com/pulumi/pulumi-equinix-metal/sdk/v2/go/equinix"
+	metal "github.com/pulumi/pulumi-equinix-metal/sdk/v3/go/equinix"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/gcp-go/go.mod
+++ b/gcp-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.17
 
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v6 v6.45.0
+	github.com/pulumi/pulumi-gcp/sdk/v6 v6.46.0
 	github.com/pulumi/pulumi/sdk/v3 v3.51.0
 )

--- a/generator/mod-templates/equinix-metal-template.txt
+++ b/generator/mod-templates/equinix-metal-template.txt
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.17
 
 require (
-	github.com/pulumi/pulumi-equinix-metal/sdk/v2 ${VERSION}
+	github.com/pulumi/pulumi-equinix-metal/sdk/v3 ${VERSION}
 	github.com/pulumi/pulumi/sdk/v3 ${PULUMI_VERSION}
 )

--- a/github-go/go.mod
+++ b/github-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.17
 
 require (
-	github.com/pulumi/pulumi-github/sdk/v4 v5.1.0
+	github.com/pulumi/pulumi-github/sdk/v4 v4.17.0
 	github.com/pulumi/pulumi/sdk/v3 v3.51.0
 )


### PR DESCRIPTION
Running this script without a `GITHUB_TOKEN` [occasionally yields `null` values in `go.mod` files](https://github.com/pulumi/templates/pull/493) because of GitHub rate limiting. This change adds the ambient `GITHUB_TOKEN` to `curl` request headers and re-runs the script to regenerate updated values.  

Also "downgrades" `github-go` to `v4` while we sort out what's going on with #481.