### PR TITLE
Temporarily comment pulumi-version: dev CLI tests

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -36,7 +36,10 @@ jobs:
         node-version: [14.x]
         python-version: [3.7]
         dotnet: [6.0.x]
-        pulumi-version: [latest, dev]
+        pulumi-version:
+          - latest
+          # Temporarily commented per https://github.com/pulumi/templates/issues/388.
+          # - dev
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: read


### PR DESCRIPTION
This change temporarily removes testing of the "dev" CLI while the linked issue is worked out.

Fixes https://github.com/pulumi/templates/issues/388.