### PR TITLE
Bump Node versions and types to ^16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-latest]
         go-version: [1.18.x]
-        node-version: [14.x]
+        node-version: [16.x]
         python-version: [3.7]
         dotnet: [6.0.x]
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-latest]
         go-version: [1.18.x]
-        node-version: [14.x]
+        node-version: [16.x]
         python-version: [3.7]
         dotnet: [6.0.x]
         pulumi-version:

--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest]
         go-version: [1.18.x]
-        node-version: [14.x]
+        node-version: [16.x]
         python-version: [3.7]
         dotnet: [6.0.x]
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, windows-latest]
         go-version: [1.18.x]
-        node-version: [14.x]
+        node-version: [16.x]
         python-version: [3.7]
         dotnet: [6.0.x]
     runs-on: ${{ matrix.platform }}

--- a/alicloud-typescript/package.json
+++ b/alicloud-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/alicloud-typescript/package.json
+++ b/alicloud-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/auth0-typescript/package.json
+++ b/auth0-typescript/package.json
@@ -2,7 +2,7 @@
   "name": "${PROJECT}",
   "main": "index.ts",
   "devDependencies": {
-    "@types/node": "^18"
+    "@types/node": "^16"
   },
   "dependencies": {
     "@pulumi/pulumi": "^3.20.0",

--- a/auth0-typescript/package.json
+++ b/auth0-typescript/package.json
@@ -2,7 +2,7 @@
   "name": "${PROJECT}",
   "main": "index.ts",
   "devDependencies": {
-    "@types/node": "^14"
+    "@types/node": "^18"
   },
   "dependencies": {
     "@pulumi/pulumi": "^3.20.0",

--- a/aws-native-typescript/package.json
+++ b/aws-native-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/aws-native-typescript/package.json
+++ b/aws-native-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/aws-typescript/package.json
+++ b/aws-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/aws-typescript/package.json
+++ b/aws-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/azure-classic-typescript/package.json
+++ b/azure-classic-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/azure-classic-typescript/package.json
+++ b/azure-classic-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/azure-typescript/package.json
+++ b/azure-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/azure-typescript/package.json
+++ b/azure-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/container-aws-typescript/package.json
+++ b/container-aws-typescript/package.json
@@ -1,12 +1,12 @@
 {
-	"name": "${PROJECT}",
-	"devDependencies": {
-		"@types/node": "^14"
-	},
-	"dependencies": {
-		"typescript": "^4.0.0",
-		"@pulumi/pulumi": "^3.0.0",
-		"@pulumi/aws": "^5.10.0",
-		"@pulumi/awsx": "^1.0.0"
-	}
+    "name": "${PROJECT}",
+    "devDependencies": {
+	    "@types/node": "^18"
+    },
+    "dependencies": {
+	    "typescript": "^4.0.0",
+	    "@pulumi/pulumi": "^3.0.0",
+	    "@pulumi/aws": "^5.10.0",
+	    "@pulumi/awsx": "^1.0.0"
+    }
 }

--- a/container-aws-typescript/package.json
+++ b/container-aws-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-	    "@types/node": "^18"
+	    "@types/node": "^16"
     },
     "dependencies": {
 	    "typescript": "^4.0.0",

--- a/container-azure-typescript/package.json
+++ b/container-azure-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/azure-native": "^1.0.0",

--- a/container-azure-typescript/package.json
+++ b/container-azure-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/azure-native": "^1.0.0",

--- a/container-gcp-typescript/package.json
+++ b/container-gcp-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/docker": "^3.4.1",

--- a/container-gcp-typescript/package.json
+++ b/container-gcp-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/docker": "^3.4.1",

--- a/digitalocean-typescript/package.json
+++ b/digitalocean-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/digitalocean-typescript/package.json
+++ b/digitalocean-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/equinix-metal-typescript/package.json
+++ b/equinix-metal-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/equinix-metal-typescript/package.json
+++ b/equinix-metal-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/gcp-typescript/package.json
+++ b/gcp-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/gcp-typescript/package.json
+++ b/gcp-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/github-typescript/package.json
+++ b/github-typescript/package.json
@@ -2,7 +2,7 @@
   "name": "${PROJECT}",
   "main": "index.ts",
   "devDependencies": {
-    "@types/node": "^14"
+    "@types/node": "^18"
   },
   "dependencies": {
     "@pulumi/pulumi": "^3.19.0",

--- a/github-typescript/package.json
+++ b/github-typescript/package.json
@@ -2,7 +2,7 @@
   "name": "${PROJECT}",
   "main": "index.ts",
   "devDependencies": {
-    "@types/node": "^18"
+    "@types/node": "^16"
   },
   "dependencies": {
     "@pulumi/pulumi": "^3.19.0",

--- a/google-native-typescript/package.json
+++ b/google-native-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.1.0",

--- a/google-native-typescript/package.json
+++ b/google-native-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.1.0",

--- a/helm-kubernetes-typescript/package.json
+++ b/helm-kubernetes-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "test",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "typescript": "^4.0.0",

--- a/helm-kubernetes-typescript/package.json
+++ b/helm-kubernetes-typescript/package.json
@@ -1,11 +1,11 @@
 {
-		"name": "test",
-		"devDependencies": {
-			"@types/node": "^14"
-		},
-		"dependencies": {
-			"typescript": "^4.0.0",
-			"@pulumi/pulumi": "^3.0.0",
-			"@pulumi/kubernetes": "3.21.4"
-		}
+    "name": "test",
+    "devDependencies": {
+        "@types/node": "^18"
+    },
+    "dependencies": {
+        "typescript": "^4.0.0",
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/kubernetes": "3.21.4"
+    }
 }

--- a/kubernetes-aws-typescript/package.json
+++ b/kubernetes-aws-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "typescript": "^4.0.0",

--- a/kubernetes-aws-typescript/package.json
+++ b/kubernetes-aws-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "typescript": "^4.0.0",

--- a/kubernetes-azure-typescript/package.json
+++ b/kubernetes-azure-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/kubernetes-azure-typescript/package.json
+++ b/kubernetes-azure-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/kubernetes-gcp-typescript/package.json
+++ b/kubernetes-gcp-typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "${PROJECT}",
   "devDependencies": {
-    "@types/node": "^18"
+    "@types/node": "^16"
   },
   "dependencies": {
     "typescript": "^4.0.0",

--- a/kubernetes-gcp-typescript/package.json
+++ b/kubernetes-gcp-typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "${PROJECT}",
   "devDependencies": {
-    "@types/node": "^14"
+    "@types/node": "^18"
   },
   "dependencies": {
     "typescript": "^4.0.0",

--- a/kubernetes-typescript/package.json
+++ b/kubernetes-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/kubernetes-typescript/package.json
+++ b/kubernetes-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/linode-typescript/package.json
+++ b/linode-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/linode-typescript/package.json
+++ b/linode-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/openstack-typescript/package.json
+++ b/openstack-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/openstack-typescript/package.json
+++ b/openstack-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/serverless-aws-typescript/package.json
+++ b/serverless-aws-typescript/package.json
@@ -1,13 +1,13 @@
 {
-	"name": "${PROJECT}",
-	"devDependencies": {
-		"@types/node": "^14"
-	},
-	"dependencies": {
-		"@pulumi/aws": "^5.23.0",
-		"@pulumi/aws-apigateway": "^1.0.1",
-		"@pulumi/awsx": "^1.0.0",
-		"@pulumi/pulumi": "^3.49.0",
-		"typescript": "^4.0.0"
-	}
+    "name": "${PROJECT}",
+    "devDependencies": {
+	    "@types/node": "^18"
+    },
+    "dependencies": {
+	    "@pulumi/aws": "^5.23.0",
+	    "@pulumi/aws-apigateway": "^1.0.1",
+	    "@pulumi/awsx": "^1.0.0",
+	    "@pulumi/pulumi": "^3.49.0",
+	    "typescript": "^4.0.0"
+    }
 }

--- a/serverless-aws-typescript/package.json
+++ b/serverless-aws-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-	    "@types/node": "^18"
+	    "@types/node": "^16"
     },
     "dependencies": {
 	    "@pulumi/aws": "^5.23.0",

--- a/serverless-azure-typescript/package.json
+++ b/serverless-azure-typescript/package.json
@@ -1,12 +1,12 @@
 {
-		"name": "${PROJECT}",
-		"devDependencies": {
-			"@types/node": "^16"
-		},
-		"dependencies": {
-		"@pulumi/azure-native": "^1.89.1",
-		"@pulumi/pulumi": "^3.49.0",
-		"@pulumi/synced-folder": "^0.0.9",
-		"typescript": "^4.0.0"
+    "name": "${PROJECT}",
+    "devDependencies": {
+        "@types/node": "^16"
+    },
+    "dependencies": {
+    "@pulumi/azure-native": "^1.89.1",
+    "@pulumi/pulumi": "^3.49.0",
+    "@pulumi/synced-folder": "^0.0.9",
+    "typescript": "^4.0.0"
 	}
 }

--- a/serverless-azure-typescript/package.json
+++ b/serverless-azure-typescript/package.json
@@ -1,7 +1,7 @@
 {
 		"name": "${PROJECT}",
 		"devDependencies": {
-			"@types/node": "^14"
+			"@types/node": "^18"
 		},
 		"dependencies": {
 		"@pulumi/azure-native": "^1.89.1",

--- a/serverless-azure-typescript/package.json
+++ b/serverless-azure-typescript/package.json
@@ -1,7 +1,7 @@
 {
 		"name": "${PROJECT}",
 		"devDependencies": {
-			"@types/node": "^18"
+			"@types/node": "^16"
 		},
 		"dependencies": {
 		"@pulumi/azure-native": "^1.89.1",

--- a/serverless-gcp-typescript/package.json
+++ b/serverless-gcp-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/gcp": "^6.45.0",

--- a/serverless-gcp-typescript/package.json
+++ b/serverless-gcp-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/gcp": "^6.45.0",

--- a/static-website-aws-typescript/package.json
+++ b/static-website-aws-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/aws": "^5.23.0",

--- a/static-website-aws-typescript/package.json
+++ b/static-website-aws-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/aws": "^5.23.0",

--- a/static-website-azure-typescript/package.json
+++ b/static-website-azure-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/azure-native": "^1.89.1",

--- a/static-website-azure-typescript/package.json
+++ b/static-website-azure-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/azure-native": "^1.89.1",

--- a/static-website-gcp-typescript/package.json
+++ b/static-website-gcp-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/gcp": "^6.45.0",

--- a/static-website-gcp-typescript/package.json
+++ b/static-website-gcp-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/gcp": "^6.45.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0"

--- a/vm-aws-typescript/package.json
+++ b/vm-aws-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "typescript": "^4.0.0",

--- a/vm-aws-typescript/package.json
+++ b/vm-aws-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "typescript": "^4.0.0",

--- a/vm-azure-typescript/package.json
+++ b/vm-azure-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "vm-azure-typescript",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/azure-native": "^1.0.0",

--- a/vm-azure-typescript/package.json
+++ b/vm-azure-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "vm-azure-typescript",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/azure-native": "^1.0.0",

--- a/vm-gcp-typescript/package.json
+++ b/vm-gcp-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/vm-gcp-typescript/package.json
+++ b/vm-gcp-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/webapp-kubernetes-typescript/package.json
+++ b/webapp-kubernetes-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "webapp-kubernetes-typescript",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^16"
     },
     "dependencies": {
         "typescript": "^4.0.0",

--- a/webapp-kubernetes-typescript/package.json
+++ b/webapp-kubernetes-typescript/package.json
@@ -1,11 +1,11 @@
 {
-		"name": "webapp-kubernetes-typescript",
-		"devDependencies": {
-			"@types/node": "^14"
-		},
-		"dependencies": {
-			"typescript": "^4.0.0",
-			"@pulumi/pulumi": "^3.0.0",
-			"@pulumi/kubernetes": "3.21.4"
-		}
+    "name": "webapp-kubernetes-typescript",
+    "devDependencies": {
+        "@types/node": "^18"
+    },
+    "dependencies": {
+        "typescript": "^4.0.0",
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/kubernetes": "3.21.4"
+    }
 }


### PR DESCRIPTION
Brings to [one version behind current](https://github.com/nodejs/release#release-schedule). Also upgrades to Node 16 on the runners.

Fixes https://github.com/pulumi/templates/issues/507.