### PR TITLE
Bump go versions to 1.18

### DIFF
--- a/aiven-go/go.mod
+++ b/aiven-go/go.mod
@@ -1,9 +1,8 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-aiven/sdk/v5 v5.4.0
 	github.com/pulumi/pulumi/sdk/v3 v3.51.0
 )
-

--- a/alicloud-go/go.mod
+++ b/alicloud-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-alicloud/sdk/v3 v3.28.0

--- a/auth0-go/go.mod
+++ b/auth0-go/go.mod
@@ -1,11 +1,8 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-auth0/sdk/v2 v2.14.0
 	github.com/pulumi/pulumi/sdk/v3 v3.51.0
 )
-
-
-

--- a/aws-go/go.mod
+++ b/aws-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v5 v5.27.0

--- a/aws-native-go/go.mod
+++ b/aws-native-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-aws-native/sdk v0.8.0

--- a/azure-classic-go/go.mod
+++ b/azure-classic-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-azure/sdk/v5 v5.30.0

--- a/azure-go/go.mod
+++ b/azure-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-azure-native/sdk v1.91.0

--- a/civo-go/go.mod
+++ b/civo-go/go.mod
@@ -1,9 +1,8 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-civo/sdk/v2 v2.3.1
 	github.com/pulumi/pulumi/sdk/v3 v3.51.0
 )
-

--- a/container-aws-go/go.mod
+++ b/container-aws-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v5 v5.10.0

--- a/container-azure-go/go.mod
+++ b/container-azure-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-azure-native-sdk/containerinstance v1.88.1

--- a/container-gcp-go/go.mod
+++ b/container-gcp-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-gcp/sdk/v6 v6.36.0

--- a/digitalocean-go/go.mod
+++ b/digitalocean-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-digitalocean/sdk/v4 v4.16.0

--- a/equinix-metal-go/go.mod
+++ b/equinix-metal-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-equinix-metal/sdk/v3 v3.2.1

--- a/gcp-go/go.mod
+++ b/gcp-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-gcp/sdk/v6 v6.46.0

--- a/github-go/go.mod
+++ b/github-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-github/sdk/v4 v4.17.0

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.51.0

--- a/google-native-go/go.mod
+++ b/google-native-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-google-native/sdk v0.27.0

--- a/kubernetes-aws-go/go.mod
+++ b/kubernetes-aws-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-awsx/sdk v1.0.0

--- a/kubernetes-azure-go/go.mod
+++ b/kubernetes-azure-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-azure-native-sdk/containerservice v1.88.1

--- a/kubernetes-gcp-go/go.mod
+++ b/kubernetes-gcp-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 v3.30.0

--- a/kubernetes-go/go.mod
+++ b/kubernetes-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.23.1

--- a/linode-go/go.mod
+++ b/linode-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-linode/sdk/v3 v3.10.1

--- a/oci-go/go.mod
+++ b/oci-go/go.mod
@@ -1,9 +1,8 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-oci/sdk v0.5.0
 	github.com/pulumi/pulumi/sdk/v3 v3.51.0
 )
-

--- a/openstack-go/go.mod
+++ b/openstack-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-openstack/sdk/v3 v3.9.0

--- a/serverless-aws-go/go.mod
+++ b/serverless-aws-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-aws-apigateway/sdk v1.0.1

--- a/serverless-azure-go/go.mod
+++ b/serverless-azure-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-azure-native-sdk/resources v1.89.1

--- a/serverless-gcp-go/go.mod
+++ b/serverless-gcp-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-gcp/sdk/v6 v6.45.0

--- a/static-website-aws-go/go.mod
+++ b/static-website-aws-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v5 v5.23.0

--- a/static-website-azure-go/go.mod
+++ b/static-website-azure-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-azure-native-sdk/cdn v1.89.1

--- a/static-website-gcp-go/go.mod
+++ b/static-website-gcp-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-gcp/sdk/v6 v6.45.0

--- a/vm-aws-go/go.mod
+++ b/vm-aws-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v5 v5.18.0


### PR DESCRIPTION
Brings to [one version behind current](https://go.dev/doc/devel/release#policy).

Fixes https://github.com/pulumi/templates/issues/508.