### PR TITLE
Fix environment-variable reference

### DIFF
--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -17,7 +17,7 @@ env:
   GOOGLE_PROJECT: pulumi-ci-gcp-provider
   GOOGLE_PROJECT_NUMBER: 895284651812
   LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
-  SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container,vm-azure-yaml,kubernetes-azure-yaml,github-go"
+  SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container,vm-azure-yaml"
   PULUMI_API: https://api.pulumi-staging.io
   ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
@@ -25,6 +25,7 @@ env:
   ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
   AZURE_LOCATION: westus
   TESTPARALLELISM: 10
+  PULUMI_TEMPLATE_LOCATION: ${{ github.workspace}}
 jobs:
   sentinel:
     if: github.event_name == 'repository_dispatch' ||
@@ -104,17 +105,12 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v0
         with:
-          workload_identity_provider: projects/${{ env.GOOGLE_PROJECT_NUMBER
-            }}/locations/global/workloadIdentityPools/${{
-            env.GOOGLE_CI_WORKLOAD_IDENTITY_POOL }}/providers/${{
-            env.GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: projects/${{ env.GOOGLE_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ env.GOOGLE_CI_WORKLOAD_IDENTITY_POOL }}/providers/${{ env.GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.GOOGLE_CI_SERVICE_ACCOUNT_EMAIL }}
       - name: Setup gcloud auth
         uses: google-github-actions/setup-gcloud@v0
         with:
           install_components: gke-gcloud-auth-plugin
-      - name: Set the Template URL using local repo path
-        run: echo "PULUMI_TEMPLATE_LOCATION=${{ github.workspace}}" >> $GITHUB_ENV
       - name: Install gotestfmt
         uses: jaxxstorm/action-install-gh-release@v1.3.1
         with:
@@ -130,6 +126,7 @@ jobs:
         env:
           PULUMI_PYTHON_CMD: python
           TESTPARALLELISM: 3
+          SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container,vm-azure-yaml,fsharp,gcp-visualbasic,azure-classic-visualbasic"
       - if: contains(matrix.platform, 'macOS')
         name: Running macOS tests
         run: |

--- a/fsharp/${PROJECT}.fsproj
+++ b/fsharp/${PROJECT}.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/fsharp/Program.fs
+++ b/fsharp/Program.fs
@@ -1,13 +1,13 @@
-﻿module Program
+module Program
 
 open Pulumi.FSharp
 
 let infra () =
   //
-  // Add you resources here
+  // Add your resources here.
   //
 
-  // Export outputs here
+  // Export outputs here.
   dict []
 
 [<EntryPoint>]

--- a/tests/internal/testutils/templates.go
+++ b/tests/internal/testutils/templates.go
@@ -1,7 +1,7 @@
 package testutils
 
 import (
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,7 +32,7 @@ func FindAllTemplates(t *testing.T, templateUrl string) []TemplateInfo {
 		templateName := t.Name
 		templatePath := templateName
 		if templateUrl != "" {
-			templatePath = path.Join(templateUrl, templateName)
+			templatePath = filepath.Join(templateUrl, templateName)
 		}
 
 		infos = append(infos, TemplateInfo{


### PR DESCRIPTION
Our PR tests use an environment variable, `PULUMI_TEMPLATE_LOCATION`, to pass the path of the checked-out branch to `pulumi new` to ensure that the tests run against the content of the PR. This environment variable, however, hasn't been getting set for some time, so the tests have actually been running against the templates in pulumi/templates@master, using  the default behavior of `pulumi new` (which clones over https). This change fixes that.

Interestingly, this change also seems to have surfaced new failures on Windows; specifically, all of the `fsharp` templates are now failing on the Windows runners, and a couple of `visualbasic` ones are now, too. This appears to have something to do with a UTF-8 byte-order mark that's apparently set by Visual Studio on Windows, but removing those marks doesn't seem to fix it, so for now, since I've verified these templates actually do work on Windows, and the issue seems specific to running `pulumi new` with a file path, I've commented them out as well, and will file an issue to investigate further.