### PR TITLE
Upgrade actions to address warnings

### DIFF
--- a/.github/workflows/build-metadata.yml
+++ b/.github/workflows/build-metadata.yml
@@ -9,19 +9,19 @@ jobs:
     name: Build
     steps:
       - name: Install Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
-      
+          node-version: 16.x
+
       - name: Check out branch
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
-      
+
       - name: Build metadata
         run: |
           make metadata
-      
+
       - name: Publish metadata.json file
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - name: Install DotNet ${{ matrix.dotnet }}
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ matrix.dotnet }}
       - if: contains(matrix.platform, 'ubuntu') || contains(matrix.platform, 'windows')
@@ -60,7 +60,7 @@ jobs:
         run: |
           dotnet nuget locals all --clear
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Set up Go ${{ matrix.go-version }}
@@ -70,15 +70,15 @@ jobs:
       - run: go env
       - name: Install Latest Pulumi CLI
         if: env.PULUMI_VERSION == ''
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/setup-pulumi@v2
       - name: Install Specific Version of Pulumi CLI
         if: env.PULUMI_VERSION != ''
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/setup-pulumi@v2
         with:
           pulumi-version: ${{ env.PULUMI_VERSION }}
       - run: pulumi version
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Python Deps
@@ -111,7 +111,7 @@ jobs:
         with:
           install_components: gke-gcloud-auth-plugin
       - name: Install gotestfmt
-        uses: jaxxstorm/action-install-gh-release@v1.3.1
+        uses: jaxxstorm/action-install-gh-release@v1.9.0
         with:
           repo: gotesttools/gotestfmt
       - name: Get dependencies

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -51,7 +51,7 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - name: Install DotNet ${{ matrix.dotnet }}
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ matrix.dotnet }}
       - if: contains(matrix.platform, 'ubuntu') || contains(matrix.platform, 'windows')
@@ -59,7 +59,7 @@ jobs:
         run: |
           dotnet nuget locals all --clear
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Set up Go ${{ matrix.go-version }}
@@ -68,7 +68,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - if: matrix.pulumi-version == 'latest'
         name: Install Latest Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1
+        uses: pulumi/setup-pulumi@v2
       - if: matrix.pulumi-version == 'dev'
         name: Get Latest Dev Version of Pulumi
         shell: bash
@@ -76,12 +76,12 @@ jobs:
           echo "DEV_PULUMI_VERSION=$(curl -sSL "http://registry.npmjs.org/-/package/@pulumi/pulumi/dist-tags" | jq -r .dev)" >> $GITHUB_ENV
       - if: matrix.pulumi-version == 'dev'
         name: Install Latest Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1
+        uses: pulumi/setup-pulumi@v2
         with:
           pulumi-version: ${{ env.DEV_PULUMI_VERSION }}
       - run: echo "Currently Pulumi $(pulumi version) is installed"
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Python Deps
@@ -114,7 +114,7 @@ jobs:
         with:
           install_components: gke-gcloud-auth-plugin
       - name: Install gotestfmt
-        uses: jaxxstorm/action-install-gh-release@v1.3.1
+        uses: jaxxstorm/action-install-gh-release@v1.9.0
         with:
           repo: gotesttools/gotestfmt
       - name: Get dependencies

--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -47,7 +47,7 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - name: Install DotNet ${{ matrix.dotnet }}
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{matrix.dotnet}}
       - if: contains(matrix.platform, 'windows')
@@ -55,11 +55,11 @@ jobs:
         run: |
           dotnet nuget locals all --clear
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node-version}}
       - name: Install Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{matrix.python-version}}
       - name: Install Go ${{ matrix.go-version }}
@@ -71,7 +71,7 @@ jobs:
           pip3 install virtualenv==20.0.23
           pip3 install pipenv
       - name: Install gotestfmt
-        uses: jaxxstorm/action-install-gh-release@v1.7.1
+        uses: jaxxstorm/action-install-gh-release@v1.9.0
         with:
           repo: gotesttools/gotestfmt
       - uses: actions/checkout@v3

--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -58,7 +58,7 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - name: Install DotNet ${{ matrix.dotnet }}
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ matrix.dotnet }}
       - if: contains(matrix.platform, 'ubuntu') || contains(matrix.platform, 'windows')
@@ -66,7 +66,7 @@ jobs:
         run: |
           dotnet nuget locals all --clear
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Set up Go ${{ matrix.go-version }}
@@ -75,10 +75,10 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - run: go env
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/setup-pulumi@v2
       - run: pulumi version
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Python Deps
@@ -112,7 +112,7 @@ jobs:
         with:
           install_components: gke-gcloud-auth-plugin
       - name: Install gotestfmt
-        uses: jaxxstorm/action-install-gh-release@v1.3.1
+        uses: jaxxstorm/action-install-gh-release@v1.9.0
         with:
           repo: gotesttools/gotestfmt
       - name: Get dependencies
@@ -137,17 +137,3 @@ jobs:
         run: |
           set -euo pipefail
           cd tests && go test -v -json -count=1 -cover -timeout 6h -parallel ${{ env.TESTPARALLELISM }} . 2>&1 | gotestfmt
-      - name: Create URL to the run output
-        id: vars
-        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-      - name: Update with Result
-        if: github.event_name == 'repository_dispatch'
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
-          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
-          body: |
-            Please view the results of the PR Build [Here][1]
-
-            [1]: ${{ steps.vars.outputs.run-url }}

--- a/.github/workflows/test-metadata.yml
+++ b/.github/workflows/test-metadata.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
 


### PR DESCRIPTION
We've accumulated a number of warnings in our actions results:

![image](https://user-images.githubusercontent.com/274700/213056105-70a7d9fa-c4e6-46c8-a6c8-ac3acca68f32.png)

To address these warnings, this change upgrades everything that can be upgraded and removes the one step we have that uses `set-output`. Couple notes:

* pulumi/actions-install-pulumi-cli is now called [pulumi/setup-pulumi](https://github.com/pulumi/setup-pulumi) and has been upgraded to the latest version, but the latest version unfortunately still runs Node 12. https://github.com/pulumi/setup-pulumi/issues/36 tracks addressing that.
* aws-actions/configure-aws-credentials also still runs on Node 12, so will continue to warn until https://github.com/aws-actions/configure-aws-credentials/issues/489 is addressed.
* The step that uses `set-output` appears to post a comment with a link back to the build job, presumably for external contributors, but since contributors can easily navigate to these build jobs in the usual way (i.e., by clicking the Details links in the Checks result), it's superfluous, so I've chosen to remove rather than refactor it.

Fixes https://github.com/pulumi/templates/issues/509.