### PR TITLE
Run `push` jobs against local checkout as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: Run Template Tests on Push or as Part of a Release
 on:
-
-  # Temporary to test this change.
-  pull_request:
-  # push:
-
+  push:
     branches:
       - master
   workflow_dispatch: {}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: Run Template Tests on Push or as Part of a Release
 on:
-  push:
+
+  # Temporary to test this change.
+  pull_request:
+  # push:
+
     branches:
       - master
   workflow_dispatch: {}
@@ -19,7 +23,7 @@ env:
   GOOGLE_PROJECT: pulumi-ci-gcp-provider
   GOOGLE_PROJECT_NUMBER: 895284651812
   LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
-  SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container,vm-azure-yaml,kubernetes-azure-yaml,github-go"
+  SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container,vm-azure"
   PULUMI_API: https://api.pulumi-staging.io
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_VERSION: ${{ github.event.client_payload.ref }}
@@ -29,7 +33,7 @@ env:
   ARM_TENANT_ID:  ${{ secrets.ARM_TENANT_ID }}
   AZURE_LOCATION: westus
   TESTPARALLELISM: 10
-
+  PULUMI_TEMPLATE_LOCATION: ${{ github.workspace}}
 jobs:
   build:
     name: Build
@@ -101,10 +105,7 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v0
         with:
-          workload_identity_provider: projects/${{ env.GOOGLE_PROJECT_NUMBER
-            }}/locations/global/workloadIdentityPools/${{
-            env.GOOGLE_CI_WORKLOAD_IDENTITY_POOL }}/providers/${{
-            env.GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: projects/${{ env.GOOGLE_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ env.GOOGLE_CI_WORKLOAD_IDENTITY_POOL }}/providers/${{ env.GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.GOOGLE_CI_SERVICE_ACCOUNT_EMAIL }}
       - name: Setup gcloud auth
         uses: google-github-actions/setup-gcloud@v0
@@ -125,6 +126,7 @@ jobs:
         env:
           PULUMI_PYTHON_CMD: python
           TESTPARALLELISM: 3
+          SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,container,vm-azure,fsharp,gcp-visualbasic,azure-classic-visualbasic"
       - if: contains(matrix.platform, 'macos')
         name: Running macOS tests
         run: |


### PR DESCRIPTION
Updates the `push` tests to run against the local checkout also (as we do for PRs, as of https://github.com/pulumi/templates/pull/500). Should make the README badge go green. 🤞 

Fixes https://github.com/pulumi/templates/issues/510.