### PR TITLE
Change default instance type

### DIFF
--- a/kubernetes-aws-csharp/Program.cs
+++ b/kubernetes-aws-csharp/Program.cs
@@ -10,7 +10,7 @@ return await Deployment.RunAsync(() =>
     var minClusterSize = config.GetInt32("minClusterSize") ?? 3;
     var maxClusterSize = config.GetInt32("maxClusterSize") ?? 6;
     var desiredClusterSize = config.GetInt32("desiredClusterSize") ?? 3;
-    var eksNodeInstanceType = config.Get("eksNodeInstanceType") ?? "t2.medium";
+    var eksNodeInstanceType = config.Get("eksNodeInstanceType") ?? "t3.medium";
     var vpcNetworkCidr = config.Get("vpcNetworkCidr") ?? "10.0.0.0/16";
 
     // Create a new VPC

--- a/kubernetes-aws-csharp/Pulumi.yaml
+++ b/kubernetes-aws-csharp/Pulumi.yaml
@@ -18,7 +18,7 @@ template:
       default: 3
     eksNodeInstanceType:
       description: Instance type to use for worker nodes
-      default: t2.medium
+      default: t3.medium
     vpcNetworkCidr:
       description: Network CIDR to use for new VPC
       default: 10.0.0.0/16

--- a/kubernetes-aws-go/Pulumi.yaml
+++ b/kubernetes-aws-go/Pulumi.yaml
@@ -18,7 +18,7 @@ template:
       default: 3
     eksNodeInstanceType:
       description: Instance type to use for worker nodes
-      default: t2.medium
+      default: t3.medium
     vpcNetworkCidr:
       description: Network CIDR to use for new VPC
       default: 10.0.0.0/16

--- a/kubernetes-aws-go/main.go
+++ b/kubernetes-aws-go/main.go
@@ -25,7 +25,7 @@ func main() {
 		}
 		eksNodeInstanceType, err := cfg.Try("eksNodeInstanceType")
 		if err != nil {
-			eksNodeInstanceType = "t2.medium"
+			eksNodeInstanceType = "t3.medium"
 		}
 		vpcNetworkCidr, err := cfg.Try("vpcNetworkCidr")
 		if err != nil {
@@ -44,16 +44,16 @@ func main() {
 		// Create a new EKS cluster
 		eksCluster, err := eks.NewCluster(ctx, "eks-cluster", &eks.ClusterArgs{
 			// Put the cluster in the new VPC created earlier
-			VpcId:                        eksVpc.VpcId,
+			VpcId: eksVpc.VpcId,
 			// Public subnets will be used for load balancers
-			PublicSubnetIds:              eksVpc.PublicSubnetIds,
+			PublicSubnetIds: eksVpc.PublicSubnetIds,
 			// Private subnets will be used for cluster nodes
-			PrivateSubnetIds:             eksVpc.PrivateSubnetIds,
+			PrivateSubnetIds: eksVpc.PrivateSubnetIds,
 			// Change configuration values above to change any of the following settings
-			InstanceType:                 pulumi.String(eksNodeInstanceType),
-			DesiredCapacity:              pulumi.Int(desiredClusterSize),
-			MinSize:                      pulumi.Int(minClusterSize),
-			MaxSize:                      pulumi.Int(maxClusterSize),
+			InstanceType:    pulumi.String(eksNodeInstanceType),
+			DesiredCapacity: pulumi.Int(desiredClusterSize),
+			MinSize:         pulumi.Int(minClusterSize),
+			MaxSize:         pulumi.Int(maxClusterSize),
 			// Do not give the worker nodes a public IP address
 			NodeAssociatePublicIpAddress: pulumi.Bool(false),
 			// Uncomment the next two lines for a private cluster (VPN access required)

--- a/kubernetes-aws-python/Pulumi.yaml
+++ b/kubernetes-aws-python/Pulumi.yaml
@@ -18,7 +18,7 @@ template:
       default: 3
     eksNodeInstanceType:
       description: Instance type to use for worker nodes
-      default: t2.medium
+      default: t3.medium
     vpcNetworkCidr:
       description: Network CIDR to use for new VPC
       default: 10.0.0.0/16

--- a/kubernetes-aws-python/__main__.py
+++ b/kubernetes-aws-python/__main__.py
@@ -7,7 +7,7 @@ config = pulumi.Config()
 min_cluster_size = config.get_float("minClusterSize", 3)
 max_cluster_size = config.get_float("maxClusterSize", 6)
 desired_cluster_size = config.get_float("desiredClusterSize", 3)
-eks_node_instance_type = config.get("eksNodeInstanceType", "t2.medium")
+eks_node_instance_type = config.get("eksNodeInstanceType", "t3.medium")
 vpc_network_cidr = config.get("vpcNetworkCidr", "10.0.0.0/16")
 
 # Create a VPC for the EKS cluster

--- a/kubernetes-aws-typescript/Pulumi.yaml
+++ b/kubernetes-aws-typescript/Pulumi.yaml
@@ -18,7 +18,7 @@ template:
       default: 3
     eksNodeInstanceType:
       description: Instance type to use for worker nodes
-      default: t2.medium
+      default: t3.medium
     vpcNetworkCidr:
       description: Network CIDR to use for new VPC
       default: 10.0.0.0/16

--- a/kubernetes-aws-typescript/index.ts
+++ b/kubernetes-aws-typescript/index.ts
@@ -7,7 +7,7 @@ const config = new pulumi.Config();
 const minClusterSize = config.getNumber("minClusterSize") || 3;
 const maxClusterSize = config.getNumber("maxClusterSize") || 6;
 const desiredClusterSize = config.getNumber("desiredClusterSize") || 3;
-const eksNodeInstanceType = config.get("eksNodeInstanceType") || "t2.medium";
+const eksNodeInstanceType = config.get("eksNodeInstanceType") || "t3.medium";
 const vpcNetworkCidr = config.get("vpcNetworkCidr") || "10.0.0.0/16";
 
 // Create a new VPC

--- a/kubernetes-aws-yaml/Pulumi.yaml
+++ b/kubernetes-aws-yaml/Pulumi.yaml
@@ -18,7 +18,7 @@ template:
       default: 3
     eksNodeInstanceType:
       description: Instance type to use for worker nodes
-      default: t2.medium
+      default: t3.medium
     vpcNetworkCidr:
       description: Network CIDR to use for new VPC
       default: 10.0.0.0/16
@@ -34,7 +34,7 @@ config:
     default: 3
   eksNodeInstanceType:
     type: string
-    default: t2.medium
+    default: t3.medium
   vpcNetworkCidr:
     type: string
     default: 10.0.0.0/16

--- a/kubernetes-aws-yaml/Pulumi.yaml.append
+++ b/kubernetes-aws-yaml/Pulumi.yaml.append
@@ -10,7 +10,7 @@ config:
     default: 3
   eksNodeInstanceType:
     type: string
-    default: t2.medium
+    default: t3.medium
   vpcNetworkCidr:
     type: string
     default: 10.0.0.0/16


### PR DESCRIPTION
This PR changes the default instance type for Kubernetes templates from t2 to t3 (t2 is not supported in all regions). Based on research using `aws ec2 describe-instance-type-offerings`, the t3 family appears to be supported in all (or very nearly all) regions and is a better option for a default value.

Fixes #501 
