### PR TITLE
Fix go.mod templating script

### DIFF
--- a/.github/workflows/update-templates.yml
+++ b/.github/workflows/update-templates.yml
@@ -25,13 +25,13 @@ jobs:
           git config --local user.name "pulumi-bot"
           git checkout -b templates/${{ github.run_id }}-${{ github.run_number }}
           git add .
-          git commit -m "Regenerating templates for updated go.mod files"
+          git commit -m "Update Go template dependencies to their latest versions"
           git push origin templates/${{ github.run_id }}-${{ github.run_number }}
       - name: pull-request
         uses: repo-sync/pull-request@v2
         with:
           source_branch: "templates/${{ github.run_id }}-${{ github.run_number }}"
           destination_branch: "master"
-          pr_title: "Regenerating Templates based on go.mod changes"
-          pr_body: "Automated PR"
+          pr_title: "Update Go template dependencies to their latest versions"
+          pr_body: "This PR was generated automatically, most likely in response to a [pulumi/pulumi release](https://github.com/pulumi/pulumi/releases)."
           github_token: ${{ secrets.PULUMI_BOT_TOKEN }}

--- a/aiven-go/go.mod
+++ b/aiven-go/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/pulumi/pulumi-aiven/sdk/v5 v5.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.51.0
+	github.com/pulumi/pulumi/sdk/v3 v3.52.0
 )

--- a/alicloud-go/go.mod
+++ b/alicloud-go/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/pulumi/pulumi-alicloud/sdk/v3 v3.28.0
-	github.com/pulumi/pulumi/sdk/v3 v3.51.0
+	github.com/pulumi/pulumi/sdk/v3 v3.52.0
 )

--- a/auth0-go/go.mod
+++ b/auth0-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-auth0/sdk/v2 v2.14.0
-	github.com/pulumi/pulumi/sdk/v3 v3.51.0
+	github.com/pulumi/pulumi-auth0/sdk/v2 v2.15.0
+	github.com/pulumi/pulumi/sdk/v3 v3.52.0
 )

--- a/aws-go/go.mod
+++ b/aws-go/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v5 v5.27.0
-	github.com/pulumi/pulumi/sdk/v3 v3.51.0
+	github.com/pulumi/pulumi/sdk/v3 v3.52.0
 )

--- a/aws-native-go/go.mod
+++ b/aws-native-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-aws-native/sdk v0.8.0
-	github.com/pulumi/pulumi/sdk/v3 v3.19.0
+	github.com/pulumi/pulumi-aws-native/sdk v0.47.0
+	github.com/pulumi/pulumi/sdk/v3 v3.52.0
 )

--- a/azure-classic-go/go.mod
+++ b/azure-classic-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-azure/sdk/v5 v5.30.0
-	github.com/pulumi/pulumi/sdk/v3 v3.51.0
+	github.com/pulumi/pulumi-azure/sdk/v5 v5.31.0
+	github.com/pulumi/pulumi/sdk/v3 v3.52.0
 )

--- a/azure-go/go.mod
+++ b/azure-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-azure-native/sdk v1.91.0
-	github.com/pulumi/pulumi/sdk/v3 v3.51.0
+	github.com/pulumi/pulumi-azure-native/sdk v1.92.0
+	github.com/pulumi/pulumi/sdk/v3 v3.52.0
 )

--- a/civo-go/go.mod
+++ b/civo-go/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/pulumi/pulumi-civo/sdk/v2 v2.3.1
-	github.com/pulumi/pulumi/sdk/v3 v3.51.0
+	github.com/pulumi/pulumi/sdk/v3 v3.52.0
 )

--- a/digitalocean-go/go.mod
+++ b/digitalocean-go/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/pulumi/pulumi-digitalocean/sdk/v4 v4.16.0
-	github.com/pulumi/pulumi/sdk/v3 v3.51.0
+	github.com/pulumi/pulumi/sdk/v3 v3.52.0
 )

--- a/equinix-metal-go/go.mod
+++ b/equinix-metal-go/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/pulumi/pulumi-equinix-metal/sdk/v3 v3.2.1
-	github.com/pulumi/pulumi/sdk/v3 v3.51.0
+	github.com/pulumi/pulumi/sdk/v3 v3.52.0
 )

--- a/gcp-go/go.mod
+++ b/gcp-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v6 v6.46.0
-	github.com/pulumi/pulumi/sdk/v3 v3.51.0
+	github.com/pulumi/pulumi-gcp/sdk/v6 v6.47.0
+	github.com/pulumi/pulumi/sdk/v3 v3.52.0
 )

--- a/generator/generate-go-mod.sh
+++ b/generator/generate-go-mod.sh
@@ -14,7 +14,7 @@ fetch_latest_version() {
 
 PULUMI_VERSION="$(fetch_latest_version pulumi)"
 
-PROVIDER_LIST="alicloud,aws,azure-classic,azure,digitalocean,equinix-metal,gcp,google-native,kubernetes,linode,openstack,civo,aiven,auth0,oci"
+PROVIDER_LIST="aiven,alicloud,auth0,aws,aws-native,azure,azure-classic,civo,digitalocean,equinix-metal,gcp,google-native,kubernetes,linode,oci,openstack"
 IFS=',' read -ra PROVIDERS <<< "$PROVIDER_LIST"
 
 for i in "${PROVIDERS[@]}"

--- a/generator/mod-templates/aiven-template.txt
+++ b/generator/mod-templates/aiven-template.txt
@@ -1,9 +1,8 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-aiven/sdk/v5 ${VERSION}
 	github.com/pulumi/pulumi/sdk/v3 ${PULUMI_VERSION}
 )
-

--- a/generator/mod-templates/alicloud-template.txt
+++ b/generator/mod-templates/alicloud-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-alicloud/sdk/v3 ${VERSION}

--- a/generator/mod-templates/auth0-template.txt
+++ b/generator/mod-templates/auth0-template.txt
@@ -1,11 +1,8 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-auth0/sdk/v2 ${VERSION}
 	github.com/pulumi/pulumi/sdk/v3 ${PULUMI_VERSION}
 )
-
-
-

--- a/generator/mod-templates/aws-native-template.txt
+++ b/generator/mod-templates/aws-native-template.txt
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-azure-native/sdk ${VERSION}
+	github.com/pulumi/pulumi-aws-native/sdk ${VERSION}
 	github.com/pulumi/pulumi/sdk/v3 ${PULUMI_VERSION}
 )

--- a/generator/mod-templates/aws-template.txt
+++ b/generator/mod-templates/aws-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v5 ${VERSION}

--- a/generator/mod-templates/azure-classic-template.txt
+++ b/generator/mod-templates/azure-classic-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-azure/sdk/v5 ${VERSION}

--- a/generator/mod-templates/civo-template.txt
+++ b/generator/mod-templates/civo-template.txt
@@ -1,9 +1,8 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-civo/sdk/v2 ${VERSION}
 	github.com/pulumi/pulumi/sdk/v3 ${PULUMI_VERSION}
 )
-

--- a/generator/mod-templates/digitalocean-template.txt
+++ b/generator/mod-templates/digitalocean-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-digitalocean/sdk/v4 ${VERSION}

--- a/generator/mod-templates/equinix-metal-template.txt
+++ b/generator/mod-templates/equinix-metal-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-equinix-metal/sdk/v3 ${VERSION}

--- a/generator/mod-templates/gcp-template.txt
+++ b/generator/mod-templates/gcp-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-gcp/sdk/v6 ${VERSION}

--- a/generator/mod-templates/github-template.txt
+++ b/generator/mod-templates/github-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-github/sdk/v4 ${VERSION}

--- a/generator/mod-templates/go-template.txt
+++ b/generator/mod-templates/go-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 ${PULUMI_VERSION}

--- a/generator/mod-templates/google-native-template.txt
+++ b/generator/mod-templates/google-native-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-google-native/sdk ${VERSION}

--- a/generator/mod-templates/kubernetes-template.txt
+++ b/generator/mod-templates/kubernetes-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-kubernetes/sdk/v3 ${VERSION}

--- a/generator/mod-templates/linode-template.txt
+++ b/generator/mod-templates/linode-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-linode/sdk/v3 ${VERSION}

--- a/generator/mod-templates/oci-template.txt
+++ b/generator/mod-templates/oci-template.txt
@@ -1,9 +1,8 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-oci/sdk ${VERSION}
 	github.com/pulumi/pulumi/sdk/v3 ${PULUMI_VERSION}
 )
-

--- a/generator/mod-templates/openstack-template.txt
+++ b/generator/mod-templates/openstack-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pulumi/pulumi-openstack/sdk/v3 ${VERSION}

--- a/go/go.mod
+++ b/go/go.mod
@@ -3,5 +3,5 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi/sdk/v3 v3.51.0
+	github.com/pulumi/pulumi/sdk/v3 v3.52.0
 )

--- a/google-native-go/go.mod
+++ b/google-native-go/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/pulumi/pulumi-google-native/sdk v0.27.0
-	github.com/pulumi/pulumi/sdk/v3 v3.51.0
+	github.com/pulumi/pulumi/sdk/v3 v3.52.0
 )

--- a/kubernetes-go/go.mod
+++ b/kubernetes-go/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.23.1
-	github.com/pulumi/pulumi/sdk/v3 v3.51.0
+	github.com/pulumi/pulumi/sdk/v3 v3.52.0
 )

--- a/linode-go/go.mod
+++ b/linode-go/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/pulumi/pulumi-linode/sdk/v3 v3.10.1
-	github.com/pulumi/pulumi/sdk/v3 v3.51.0
+	github.com/pulumi/pulumi/sdk/v3 v3.52.0
 )

--- a/oci-go/go.mod
+++ b/oci-go/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/pulumi/pulumi-oci/sdk v0.5.0
-	github.com/pulumi/pulumi/sdk/v3 v3.51.0
+	github.com/pulumi/pulumi/sdk/v3 v3.52.0
 )

--- a/openstack-go/go.mod
+++ b/openstack-go/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/pulumi/pulumi-openstack/sdk/v3 v3.9.0
-	github.com/pulumi/pulumi/sdk/v3 v3.51.0
+	github.com/pulumi/pulumi/sdk/v3 v3.52.0
 )


### PR DESCRIPTION
This change makes a few updates:

* Bumps the Go versions in the template files that we use to regenerate `go.mod` files (e.g., in response to a CLI release) to 1.18 (to align with the templates themselves)
* Alphabetizes the names of the providers for which we do this
* Adjusts the commit message and title of the PRs we generate from these events (to make it clearer what these PRs actually are and where they come from)
* Re-runs the script to get the `go.mod`s updated

Replaces #512.