### PR TITLE
Add scala template

### DIFF
--- a/aws-scala/Pulumi.yaml
+++ b/aws-scala/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-ops
+runtime: java
+description: A minimal AWS Scala Pulumi program

--- a/aws-scala/Pulumi.yaml
+++ b/aws-scala/Pulumi.yaml
@@ -1,3 +1,10 @@
-name: pulumi-ops
+name: ${PROJECT}
+description: ${DESCRIPTION}
 runtime: java
-description: A minimal AWS Scala Pulumi program
+template:
+  description: A minimal AWS Scala Pulumi program
+  important: true
+  config:
+    aws:region:
+      description: The AWS region to deploy into
+      default: us-east-1

--- a/aws-scala/Pulumi.yaml
+++ b/aws-scala/Pulumi.yaml
@@ -3,7 +3,6 @@ description: ${DESCRIPTION}
 runtime: java
 template:
   description: A minimal AWS Scala Pulumi program
-  important: true
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/aws-scala/build.sbt
+++ b/aws-scala/build.sbt
@@ -1,0 +1,14 @@
+val scala3Version = "3.2.2"
+
+lazy val root = project
+  .in(file("."))
+  .settings(
+    name := "Scala 3 Project Template",
+    version := "0.1.0-SNAPSHOT",
+
+    scalaVersion := scala3Version,
+
+    libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test,
+    libraryDependencies += "com.pulumi" % "pulumi" % "0.7.1",
+    libraryDependencies += "com.pulumi" % "aws" % "5.28.0"
+  )

--- a/aws-scala/src/main/scala/Main.scala
+++ b/aws-scala/src/main/scala/Main.scala
@@ -6,7 +6,11 @@ import com.pulumi.aws.s3.Bucket
 object App {
   def main(args: Array[String]): Unit = {
     Pulumi.run { (ctx: Context) =>
+
+      // Create an AWS resource (S3 Bucket)
       var bucket = new Bucket("my-bucket");
+
+      // Export the name of the bucket
       ctx.`export`("bucketName", bucket.bucket())
     }
   }

--- a/aws-scala/src/main/scala/Main.scala
+++ b/aws-scala/src/main/scala/Main.scala
@@ -1,0 +1,13 @@
+package myproject
+
+import com.pulumi.{Context, Pulumi}
+import com.pulumi.aws.s3.Bucket
+
+object App {
+  def main(args: Array[String]): Unit = {
+    Pulumi.run { (ctx: Context) =>
+      var bucket = new Bucket("my-bucket");
+      ctx.`export`("bucketName", bucket.bucket())
+    }
+  }
+}


### PR DESCRIPTION
I have noticed that while [this blog post](https://www.pulumi.com/blog/announcing-infrastructure-as-code-with-java-and-pulumi/), and [this closed issue](https://github.com/pulumi/pulumi/issues/1539) exist,
in the blog it is stated: 
> Declare infrastructure using programs, classes, and libraries written in Java or other JVM languages (Kotlin, **Scala**, Clojure, Groovy, etc.).

however, `pulumi new` command doesn't have a scala template, specifically I was looking for the aws template,
I have found 2 resources regarding an example:
https://github.com/pulumi/pulumi-java/pull/791
https://blog.ediri.io/how-to-use-pulumi-and-scala-to-deploy-a-minecraft-server-on-a-digitalocean-droplet

with those examples, I was able to recreate the same 'default' aws bucket example,
and `pulumi up` works, please consider adding this to the template list..

I know this is only aws, and it is not a all scala templates for all cloud providers, but,
This is a good start even for other providers, I know myself, I would have started with a Scala-Azure template if it was available, and just change the dependencies + imports..