### PR TITLE
github-go: Use pulumi-github v5

### DIFF
--- a/generator/mod-templates/github-template.txt
+++ b/generator/mod-templates/github-template.txt
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-github/sdk/v4 ${VERSION}
+	github.com/pulumi/pulumi-github/sdk/v5 ${VERSION}
 	github.com/pulumi/pulumi/sdk/v3 ${PULUMI_VERSION}
 )

--- a/github-go/go.mod
+++ b/github-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-github/sdk/v4 v4.17.0
+	github.com/pulumi/pulumi-github/sdk/v5 v5.3.0
 	github.com/pulumi/pulumi/sdk/v3 v3.51.0
 )

--- a/github-go/main.go
+++ b/github-go/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi-github/sdk/v4/go/github"
+	"github.com/pulumi/pulumi-github/sdk/v5/go/github"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 


### PR DESCRIPTION
pulumi-github has been v5 since
https://github.com/pulumi/pulumi-github/releases/tag/v5.0.0
but `pulumi new` still generates v4 projects.

This upgrades the github-go template to the latest v5 release.
