### PR TITLE
Force-delete repositories in container-aws templates

### DIFF
--- a/container-aws-csharp/Program.cs
+++ b/container-aws-csharp/Program.cs
@@ -3,7 +3,7 @@ using Pulumi;
 using Aws = Pulumi.Aws;
 using Awsx = Pulumi.Awsx;
 
-return await Deployment.RunAsync(() => 
+return await Deployment.RunAsync(() =>
 {
     var config = new Config();
     var containerPort = config.GetInt32("containerPort") ?? 80;
@@ -13,7 +13,10 @@ return await Deployment.RunAsync(() =>
 
     var loadbalancer = new Awsx.Lb.ApplicationLoadBalancer("loadbalancer");
 
-    var repo = new Awsx.Ecr.Repository("repo");
+    var repo = new Awsx.Ecr.Repository("repo", new()
+    {
+        ForceDelete = true,
+    });
 
     var image = new Awsx.Ecr.Image("image", new()
     {
@@ -50,4 +53,3 @@ return await Deployment.RunAsync(() =>
         ["url"] = loadbalancer.LoadBalancer.Apply(loadBalancer => Output.Format($"http://{loadBalancer.DnsName}")),
     };
 });
-

--- a/container-aws-go/go.mod
+++ b/container-aws-go/go.mod
@@ -3,59 +3,72 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v5 v5.10.0
-	github.com/pulumi/pulumi-awsx/sdk v1.0.0
-	github.com/pulumi/pulumi/sdk/v3 v3.34.1
+	github.com/pulumi/pulumi-aws/sdk/v5 v5.30.0
+	github.com/pulumi/pulumi-awsx/sdk v1.0.2
+	github.com/pulumi/pulumi/sdk/v3 v3.55.0
 )
 
 require (
 	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Microsoft/go-winio v0.6.0 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
+	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/cheggaaa/pb v1.0.18 // indirect
-	github.com/djherbis/times v1.2.0 // indirect
-	github.com/emirpasic/gods v1.12.0 // indirect
-	github.com/gofrs/uuid v3.3.0+incompatible // indirect
+	github.com/cheggaaa/pb v1.0.29 // indirect
+	github.com/cloudflare/circl v1.3.2 // indirect
+	github.com/djherbis/times v1.5.0 // indirect
+	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.4.1 // indirect
+	github.com/go-git/go-git/v5 v5.5.2 // indirect
+	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
-	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/golang/glog v1.0.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.0.0 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/imdario/mergo v0.3.13 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
-	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd // indirect
-	github.com/mattn/go-runewidth v0.0.8 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/kevinburke/ssh_config v1.2.0 // indirect
+	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
-	github.com/opentracing/basictracer-go v1.0.0 // indirect
-	github.com/opentracing/opentracing-go v1.1.0 // indirect
+	github.com/opentracing/basictracer-go v1.1.0 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pjbgf/sha1cd v0.2.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
-	github.com/pulumi/pulumi-docker/sdk/v3 v3.2.0 // indirect
-	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/rogpeppe/go-internal v1.8.1 // indirect
-	github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94 // indirect
-	github.com/sergi/go-diff v1.1.0 // indirect
-	github.com/spf13/cast v1.3.1 // indirect
-	github.com/spf13/cobra v1.4.0 // indirect
+	github.com/pulumi/pulumi-docker/sdk/v3 v3.6.1 // indirect
+	github.com/rivo/uniseg v0.4.3 // indirect
+	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.2.0 // indirect
+	github.com/sergi/go-diff v1.3.1 // indirect
+	github.com/skeema/knownhosts v1.1.0 // indirect
+	github.com/spf13/cast v1.4.1 // indirect
+	github.com/spf13/cobra v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/src-d/gcfg v1.4.0 // indirect
-	github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
-	github.com/uber/jaeger-client-go v2.22.1+incompatible // indirect
-	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
-	github.com/xanzy/ssh-agent v0.2.1 // indirect
-	go.uber.org/atomic v1.6.0 // indirect
-	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
-	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
-	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 // indirect
-	golang.org/x/text v0.3.3 // indirect
-	google.golang.org/genproto v0.0.0-20200608115520-7c474a2e3482 // indirect
-	google.golang.org/grpc v1.29.1 // indirect
-	google.golang.org/protobuf v1.24.0 // indirect
-	gopkg.in/src-d/go-billy.v4 v4.3.2 // indirect
-	gopkg.in/src-d/go-git.v4 v4.13.1 // indirect
+	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
+	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
+	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	go.uber.org/atomic v1.10.0 // indirect
+	golang.org/x/crypto v0.6.0 // indirect
+	golang.org/x/mod v0.8.0 // indirect
+	golang.org/x/net v0.7.0 // indirect
+	golang.org/x/sys v0.5.0 // indirect
+	golang.org/x/term v0.5.0 // indirect
+	golang.org/x/text v0.7.0 // indirect
+	golang.org/x/tools v0.6.0 // indirect
+	google.golang.org/genproto v0.0.0-20230216225411-c8e22ba71e44 // indirect
+	google.golang.org/grpc v1.53.0 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-	sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	lukechampine.com/frand v1.4.2 // indirect
+	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600 // indirect
 )

--- a/container-aws-go/main.go
+++ b/container-aws-go/main.go
@@ -39,7 +39,9 @@ func main() {
 		}
 
 		// An ECR repository to store our application's container image
-		repo, err := ecrx.NewRepository(ctx, "repo", nil)
+		repo, err := ecrx.NewRepository(ctx, "repo", &ecrx.RepositoryArgs{
+			ForceDelete: pulumi.Bool(true),
+		})
 		if err != nil {
 			return err
 		}

--- a/container-aws-python/__main__.py
+++ b/container-aws-python/__main__.py
@@ -14,7 +14,9 @@ cluster = aws.ecs.Cluster("cluster")
 loadbalancer = awsx.lb.ApplicationLoadBalancer("loadbalancer")
 
 # An ECR repository to store our application's container image
-repo = awsx.ecr.Repository("repo")
+repo = awsx.ecr.Repository("repo", awsx.ecr.RepositoryArgs(
+    force_delete=True,
+))
 
 # Build and publish our application's container image from ./app to the ECR repository
 image = awsx.ecr.Image(

--- a/container-aws-typescript/index.ts
+++ b/container-aws-typescript/index.ts
@@ -14,7 +14,9 @@ const cluster = new aws.ecs.Cluster("cluster", {});
 const loadbalancer = new awsx.lb.ApplicationLoadBalancer("loadbalancer", {});
 
 // An ECR repository to store our application's container image
-const repo = new awsx.ecr.Repository("repo", {});
+const repo = new awsx.ecr.Repository("repo", {
+    forceDelete: true,
+});
 
 // Build and publish our application's container image from ./app to the ECR repository
 const image = new awsx.ecr.Image("image", {

--- a/container-aws-yaml/Pulumi.yaml
+++ b/container-aws-yaml/Pulumi.yaml
@@ -35,6 +35,8 @@ resources:
   # An ECR repository to store our application's container image
   repo:
     type: awsx:ecr:Repository
+    properties:
+      forceDelete: true
   # Build and publish our application's container image from ./app to the ECR repository
   image:
     type: awsx:ecr:Image

--- a/container-aws-yaml/Pulumi.yaml.append
+++ b/container-aws-yaml/Pulumi.yaml.append
@@ -17,6 +17,8 @@ resources:
   # An ECR repository to store our application's container image
   repo:
     type: awsx:ecr:Repository
+    properties:
+      forceDelete: true
   # Build and publish our application's container image from ./app to the ECR repository
   image:
     type: awsx:ecr:Image


### PR DESCRIPTION
Adds the `forceDelete` option to `awsx.ecr.Repository` declarations to allow these resources to be destroyed along with the rest of the stack. (Currently, `pulumi destroy` fails on these templates.)

Fixes https://github.com/pulumi/templates/issues/525.