### PR TITLE
Pin java template maven dependency to latest known good version.

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -82,6 +82,15 @@
                     <mavenVersion>3.8.5</mavenVersion>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This commit pins `org.apache.maven.plugins:maven-compiler-plugin to 3.5.1` to resolve failing builds for UBI images on pulumi-docker-containers.

https://github.com/pulumi/pulumi-docker-containers/issues/127

## Context

pulumi-docker-containers has 2 different java builds.
- Debian (passing)
- UBI (failing)

UBI is failing running a test that runs the java pulumi/template with the following error message:
> Error: umi:pulumi:Stack test-env4268922448-p-it-ea7a4b0c6d-test-env42-4bd12ab9  [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.1:compile (default-compile) on project test-env4268922448: Fatal error compiling: error: release version 11 not supported -> [Help 1]

The Debian and UBI images differ on the version of `org.apache.maven.plugins:maven-compiler-plugin`

When running locally on the image with the modified `pom.xml` the build succeeds on 3.5.1, but the tested versions including 3.6.0 and latest (3.11.0 as of writing) provided the following error as of writing when running `pulumi pre` inside the UBI docker image:
```
Diagnostics:
  pulumi:pulumi:Stack (jawwa-dev):
    [WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
    [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project jawwa: Fatal error compiling: error: release version 11 not supported -> [Help 1]
    [ERROR]
    [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
    [ERROR] Re-run Maven using the -X switch to enable full debug logging.
    [ERROR]
    [ERROR] For more information about the errors and possible solutions, please read the following articles:
    [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException

    error: an unhandled error occurred: '/root/.sdkman/candidates/maven/current/bin/mvn /root/.sdkman/candidates/maven/current/bin/mvn -Dorg.slf4j.simpleLogger.defaultLogLevel=warn --no-transfer-progress compile exec:java' exited with non-zero exit code: 1
```