### PR TITLE
Conditionally test some templates end to end

### DIFF
--- a/azure-python/__main__.py
+++ b/azure-python/__main__.py
@@ -5,21 +5,27 @@ from pulumi_azure_native import storage
 from pulumi_azure_native import resources
 
 # Create an Azure Resource Group
-resource_group = resources.ResourceGroup('resource_group')
+resource_group = resources.ResourceGroup("resource_group")
 
 # Create an Azure resource (Storage Account)
-account = storage.StorageAccount('sa',
+account = storage.StorageAccount(
+    "sa",
     resource_group_name=resource_group.name,
     sku=storage.SkuArgs(
         name=storage.SkuName.STANDARD_LRS,
     ),
-    kind=storage.Kind.STORAGE_V2)
+    kind=storage.Kind.STORAGE_V2,
+)
 
 # Export the primary key of the Storage Account
-primary_key = pulumi.Output.all(resource_group.name, account.name) \
-    .apply(lambda args: storage.list_storage_account_keys(
-        resource_group_name=args[0],
-        account_name=args[1]
-    )).apply(lambda accountKeys: accountKeys.keys[0].value)
+primary_key = (
+    pulumi.Output.all(resource_group.name, account.name)
+    .apply(
+        lambda args: storage.list_storage_account_keys(
+            resource_group_name=args[0], account_name=args[1]
+        )
+    )
+    .apply(lambda accountKeys: accountKeys.keys[0].value)
+)
 
 pulumi.export("primary_storage_key", primary_key)

--- a/kubernetes-java/Pulumi.yaml
+++ b/kubernetes-java/Pulumi.yaml
@@ -3,3 +3,4 @@ description: ${DESCRIPTION}
 runtime: java
 template:
   description: A minimal Kubernetes Java Pulumi program
+  important: true

--- a/tests/internal/testutils/templates.go
+++ b/tests/internal/testutils/templates.go
@@ -42,3 +42,12 @@ func FindAllTemplates(t *testing.T, templateUrl string) []TemplateInfo {
 	}
 	return infos
 }
+
+func ListContains(list []string, item string) bool {
+	for _, a := range list {
+		if a == item {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/internal/testutils/templates.go
+++ b/tests/internal/testutils/templates.go
@@ -44,8 +44,8 @@ func FindAllTemplates(t *testing.T, templateUrl string) []TemplateInfo {
 }
 
 func ListContains(list []string, item string) bool {
-	for _, a := range list {
-		if a == item {
+	for _, s := range list {
+		if s == item {
 			return true
 		}
 	}

--- a/tests/internal/testutils/templates.go
+++ b/tests/internal/testutils/templates.go
@@ -46,11 +46,11 @@ func FindAllTemplates(t *testing.T, templateUrl string) []TemplateInfo {
 
 // UpdateOptions returns the set of integration.ProgramTestOptions that should be applied for the
 // given template.
-func UpdateOptions(templateName string) integration.ProgramTestOptions {
+func UpdateOptions(templateInfo TemplateInfo) integration.ProgramTestOptions {
 
-	// For our core Getting Started templates, we test the full end to end experience,
-	// ensuring updates succeed and subsequent operations produce no changes.
-	skipFullTest := !isGettingStartedTemplate(templateName)
+	// For templates marked important, we test the full end to end experience to ensure
+	// updates succeed and subsequent operations produce no changes.
+	skipFullTest := !templateInfo.Template.Important
 
 	return integration.ProgramTestOptions{
 		// Skip running a full update.
@@ -62,49 +62,4 @@ func UpdateOptions(templateName string) integration.ProgramTestOptions {
 		// Skip running a stack export and import after the update.
 		SkipExportImport: skipFullTest,
 	}
-}
-
-// isGettingStartedTemplate returns whether the specified template is one that is used in
-// our Getting Started flows.
-func isGettingStartedTemplate(templateName string) bool {
-	coreStarterTemplateNames := []string{
-		"aws-typescript",
-		"aws-javascript",
-		"aws-python",
-		"aws-go",
-		"aws-csharp",
-		"aws-java",
-		"aws-yaml",
-
-		"azure-typescript",
-		"azure-javascript",
-		"azure-python",
-		"azure-go",
-		"azure-csharp",
-		"azure-java",
-		"azure-yaml",
-
-		"gcp-typescript",
-		"gcp-javascript",
-		"gcp-python",
-		"gcp-go",
-		"gcp-csharp",
-		"gcp-java",
-		"gcp-yaml",
-
-		"kubernetes-typescript",
-		"kubernetes-javascript",
-		"kubernetes-python",
-		"kubernetes-go",
-		"kubernetes-csharp",
-		"kubernetes-java",
-		"kubernetes-yaml",
-	}
-
-	for _, s := range coreStarterTemplateNames {
-		if s == templateName {
-			return true
-		}
-	}
-	return false
 }

--- a/tests/internal/testutils/templates.go
+++ b/tests/internal/testutils/templates.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -43,9 +44,65 @@ func FindAllTemplates(t *testing.T, templateUrl string) []TemplateInfo {
 	return infos
 }
 
-func ListContains(list []string, item string) bool {
-	for _, s := range list {
-		if s == item {
+// UpdateOptions returns the set of integration.ProgramTestOptions that should be applied for the
+// given template.
+func UpdateOptions(templateName string) integration.ProgramTestOptions {
+
+	// For our core Getting Started templates, we test the full end to end experience,
+	// ensuring updates succeed and subsequent operations produce no changes.
+	skipFullTest := !isGettingStartedTemplate(templateName)
+
+	return integration.ProgramTestOptions{
+		// Skip running a full update.
+		SkipUpdate: skipFullTest,
+		// Skip running a refresh after the update, expecting no changes.
+		SkipRefresh: skipFullTest,
+		// Skip running a preview after the update, expecting no changes.
+		SkipPreview: skipFullTest,
+		// Skip running a stack export and import after the update.
+		SkipExportImport: skipFullTest,
+	}
+}
+
+// isGettingStartedTemplate returns whether the specified template is one that is used in
+// our Getting Started flows.
+func isGettingStartedTemplate(templateName string) bool {
+	coreStarterTemplateNames := []string{
+		"aws-typescript",
+		"aws-javascript",
+		"aws-python",
+		"aws-go",
+		"aws-csharp",
+		"aws-java",
+		"aws-yaml",
+
+		"azure-typescript",
+		"azure-javascript",
+		"azure-python",
+		"azure-go",
+		"azure-csharp",
+		"azure-java",
+		"azure-yaml",
+
+		"gcp-typescript",
+		"gcp-javascript",
+		"gcp-python",
+		"gcp-go",
+		"gcp-csharp",
+		"gcp-java",
+		"gcp-yaml",
+
+		"kubernetes-typescript",
+		"kubernetes-javascript",
+		"kubernetes-python",
+		"kubernetes-go",
+		"kubernetes-csharp",
+		"kubernetes-java",
+		"kubernetes-yaml",
+	}
+
+	for _, s := range coreStarterTemplateNames {
+		if s == templateName {
 			return true
 		}
 	}

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -23,6 +23,40 @@ func TestTemplates(t *testing.T) {
 			t.Parallel()
 		}
 
+		templatesToTest := []string{
+			"aws-typescript",
+			"aws-javascript",
+			"aws-python",
+			"aws-go",
+			"aws-csharp",
+			"aws-java",
+			"aws-yaml",
+
+			"azure-typescript",
+			"azure-javascript",
+			"azure-python",
+			"azure-go",
+			"azure-csharp",
+			"azure-java",
+			"azure-yaml",
+
+			"gcp-typescript",
+			"gcp-javascript",
+			"gcp-python",
+			"gcp-go",
+			"gcp-csharp",
+			"gcp-java",
+			"gcp-yaml",
+
+			"kubernetes-typescript",
+			"kubernetes-javascript",
+			"kubernetes-python",
+			"kubernetes-go",
+			"kubernetes-csharp",
+			"kubernetes-java",
+			"kubernetes-yaml",
+		}
+
 		testutils.RunWithTimeout(t, testTimeout, templateName, prepare, func(t *testing.T) {
 			t.Logf("Starting test run for %q", templateName)
 
@@ -41,9 +75,9 @@ func TestTemplates(t *testing.T) {
 				PrepareProject:         testutils.PrepareProject(t, e),
 				RequireService:         true,
 
-				// Skip updates to allow tests to complete more reliably.
+				// Only run full updates for select templates.
 				// See https://github.com/pulumi/devrel-team/issues/464 for details.
-				SkipUpdate: true,
+				SkipUpdate: !testutils.ListContains(templatesToTest, templateName),
 			})
 		})
 	}

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -63,21 +63,25 @@ func TestTemplates(t *testing.T) {
 			e := testutils.NewEnvironment(t, cfg)
 			testutils.PulumiNew(e, templateInfo.TemplatePath)
 
+			isStarterTemplate := !testutils.ListContains(templatesToTest, templateName)
+
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
-				Dir:                    e.RootPath,
-				Config:                 cfg.Config,
-				ExpectRefreshChanges:   true,
-				Quick:                  true,
-				SkipRefresh:            true,
+				Dir:    e.RootPath,
+				Config: cfg.Config,
+
 				NoParallel:             true, // marked Parallel by prepare
 				DestroyOnCleanup:       true,
 				UseAutomaticVirtualEnv: true,
 				PrepareProject:         testutils.PrepareProject(t, e),
 				RequireService:         true,
 
-				// Only run full updates for select templates.
-				// See https://github.com/pulumi/devrel-team/issues/464 for details.
+				// Always run full updates for core starter templates.
 				SkipUpdate: !testutils.ListContains(templatesToTest, templateName),
+
+				// Ensure there's no diff on subsequent updates.
+				SkipRefresh:      !isStarterTemplate,
+				SkipPreview:      !isStarterTemplate,
+				SkipExportImport: !isStarterTemplate,
 			})
 		})
 	}

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -37,7 +37,7 @@ func TestTemplates(t *testing.T) {
 				UseAutomaticVirtualEnv: true,
 				PrepareProject:         testutils.PrepareProject(t, e),
 				RequireService:         true,
-			}.With(testutils.UpdateOptions(templateName))
+			}.With(testutils.UpdateOptions(templateInfo))
 
 			integration.ProgramTest(t, &opts)
 		})

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -23,66 +23,23 @@ func TestTemplates(t *testing.T) {
 			t.Parallel()
 		}
 
-		templatesToTest := []string{
-			"aws-typescript",
-			"aws-javascript",
-			"aws-python",
-			"aws-go",
-			"aws-csharp",
-			"aws-java",
-			"aws-yaml",
-
-			"azure-typescript",
-			"azure-javascript",
-			"azure-python",
-			"azure-go",
-			"azure-csharp",
-			"azure-java",
-			"azure-yaml",
-
-			"gcp-typescript",
-			"gcp-javascript",
-			"gcp-python",
-			"gcp-go",
-			"gcp-csharp",
-			"gcp-java",
-			"gcp-yaml",
-
-			"kubernetes-typescript",
-			"kubernetes-javascript",
-			"kubernetes-python",
-			"kubernetes-go",
-			"kubernetes-csharp",
-			"kubernetes-java",
-			"kubernetes-yaml",
-		}
-
 		testutils.RunWithTimeout(t, testTimeout, templateName, prepare, func(t *testing.T) {
 			t.Logf("Starting test run for %q", templateName)
 
 			e := testutils.NewEnvironment(t, cfg)
 			testutils.PulumiNew(e, templateInfo.TemplatePath)
 
-			isStarterTemplate := !testutils.ListContains(templatesToTest, templateName)
-
-			integration.ProgramTest(t, &integration.ProgramTestOptions{
-				Dir:    e.RootPath,
-				Config: cfg.Config,
-
+			opts := integration.ProgramTestOptions{
+				Dir:                    e.RootPath,
+				Config:                 cfg.Config,
 				NoParallel:             true, // marked Parallel by prepare
 				DestroyOnCleanup:       true,
 				UseAutomaticVirtualEnv: true,
 				PrepareProject:         testutils.PrepareProject(t, e),
 				RequireService:         true,
+			}.With(testutils.UpdateOptions(templateName))
 
-				// Always run full updates for core starter templates.
-				SkipUpdate: !testutils.ListContains(templatesToTest, templateName),
-
-				// Ensure there's no diff on subsequent updates.
-				SkipRefresh:      !isStarterTemplate,
-				SkipPreview:      !isStarterTemplate,
-				SkipExportImport: !isStarterTemplate,
-			})
+			integration.ProgramTest(t, &opts)
 		})
 	}
 }


### PR DESCRIPTION
Adds support for applying `integration.ProgramTestOptions` on a template-by-template basis, primarily to allow us to test a subset of templates (e.g., our core starter templates) with full updates and diff checks.

Note that the checks in this PR are failing (e.g., [here](https://github.com/pulumi/templates/actions/runs/4380318017/jobs/7667248950#step:21:644)) -- this is expected until https://github.com/pulumi/pulumi-aws/issues/2403 is fixed and any necessary template dependencies in this repo are updated.  

Fixes #533.