### PR TITLE
Bump aws-go and others to pull in latest fixes

### DIFF
--- a/aiven-go/go.mod
+++ b/aiven-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-aiven/sdk/v5 v5.5.0
-	github.com/pulumi/pulumi/sdk/v3 v3.55.0
+	github.com/pulumi/pulumi-aiven/sdk/v5 v5.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.57.1
 )

--- a/alicloud-go/go.mod
+++ b/alicloud-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-alicloud/sdk/v3 v3.31.0
-	github.com/pulumi/pulumi/sdk/v3 v3.55.0
+	github.com/pulumi/pulumi-alicloud/sdk/v3 v3.33.0
+	github.com/pulumi/pulumi/sdk/v3 v3.57.1
 )

--- a/auth0-go/go.mod
+++ b/auth0-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-auth0/sdk/v2 v2.16.0
-	github.com/pulumi/pulumi/sdk/v3 v3.55.0
+	github.com/pulumi/pulumi-auth0/sdk/v2 v2.17.1
+	github.com/pulumi/pulumi/sdk/v3 v3.57.1
 )

--- a/aws-go/go.mod
+++ b/aws-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v5 v5.30.0
-	github.com/pulumi/pulumi/sdk/v3 v3.55.0
+	github.com/pulumi/pulumi-aws/sdk/v5 v5.31.0
+	github.com/pulumi/pulumi/sdk/v3 v3.57.1
 )

--- a/aws-native-go/go.mod
+++ b/aws-native-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-aws-native/sdk v0.51.0
-	github.com/pulumi/pulumi/sdk/v3 v3.55.0
+	github.com/pulumi/pulumi-aws-native/sdk v0.52.0
+	github.com/pulumi/pulumi/sdk/v3 v3.57.1
 )

--- a/azure-classic-go/go.mod
+++ b/azure-classic-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-azure/sdk/v5 v5.35.0
-	github.com/pulumi/pulumi/sdk/v3 v3.55.0
+	github.com/pulumi/pulumi-azure/sdk/v5 v5.36.0
+	github.com/pulumi/pulumi/sdk/v3 v3.57.1
 )

--- a/azure-go/go.mod
+++ b/azure-go/go.mod
@@ -3,7 +3,7 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-azure-native-sdk/resources v1.95.0
-    github.com/pulumi/pulumi-azure-native-sdk/storage v1.95.0
-	github.com/pulumi/pulumi/sdk/v3 v3.55.0
+	github.com/pulumi/pulumi-azure-native-sdk/resources v1.96.0
+    github.com/pulumi/pulumi-azure-native-sdk/storage v1.96.0
+	github.com/pulumi/pulumi/sdk/v3 v3.57.1
 )

--- a/civo-go/go.mod
+++ b/civo-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-civo/sdk/v2 v2.3.2
-	github.com/pulumi/pulumi/sdk/v3 v3.55.0
+	github.com/pulumi/pulumi-civo/sdk/v2 v2.3.3
+	github.com/pulumi/pulumi/sdk/v3 v3.57.1
 )

--- a/digitalocean-go/go.mod
+++ b/digitalocean-go/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/pulumi/pulumi-digitalocean/sdk/v4 v4.18.0
-	github.com/pulumi/pulumi/sdk/v3 v3.55.0
+	github.com/pulumi/pulumi/sdk/v3 v3.57.1
 )

--- a/equinix-metal-go/go.mod
+++ b/equinix-metal-go/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/pulumi/pulumi-equinix-metal/sdk/v3 v3.2.1
-	github.com/pulumi/pulumi/sdk/v3 v3.55.0
+	github.com/pulumi/pulumi/sdk/v3 v3.57.1
 )

--- a/gcp-go/go.mod
+++ b/gcp-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v6 v6.50.0
-	github.com/pulumi/pulumi/sdk/v3 v3.55.0
+	github.com/pulumi/pulumi-gcp/sdk/v6 v6.51.0
+	github.com/pulumi/pulumi/sdk/v3 v3.57.1
 )

--- a/go/go.mod
+++ b/go/go.mod
@@ -3,5 +3,5 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi/sdk/v3 v3.55.0
+	github.com/pulumi/pulumi/sdk/v3 v3.57.1
 )

--- a/google-native-go/go.mod
+++ b/google-native-go/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/pulumi/pulumi-google-native/sdk v0.28.0
-	github.com/pulumi/pulumi/sdk/v3 v3.55.0
+	github.com/pulumi/pulumi/sdk/v3 v3.57.1
 )

--- a/kubernetes-go/go.mod
+++ b/kubernetes-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.55.0
+	github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.24.1
+	github.com/pulumi/pulumi/sdk/v3 v3.57.1
 )

--- a/linode-go/go.mod
+++ b/linode-go/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/pulumi/pulumi-linode/sdk/v3 v3.12.0
-	github.com/pulumi/pulumi/sdk/v3 v3.55.0
+	github.com/pulumi/pulumi/sdk/v3 v3.57.1
 )

--- a/oci-go/go.mod
+++ b/oci-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-oci/sdk v0.8.0
-	github.com/pulumi/pulumi/sdk/v3 v3.55.0
+	github.com/pulumi/pulumi-oci/sdk v0.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.57.1
 )

--- a/openstack-go/go.mod
+++ b/openstack-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.18
 
 require (
-	github.com/pulumi/pulumi-openstack/sdk/v3 v3.9.0
-	github.com/pulumi/pulumi/sdk/v3 v3.55.0
+	github.com/pulumi/pulumi-openstack/sdk/v3 v3.11.0
+	github.com/pulumi/pulumi/sdk/v3 v3.57.1
 )


### PR DESCRIPTION
Updates `go.mod`s to pull in latest fixes (most importantly https://github.com/pulumi/pulumi-aws/issues/2403).