### PR TITLE
Use go 1.20x when running perf job

### DIFF
--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        go-version: [1.18.x]
+        go-version: [1.20.x]
         node-version: [16.x]
         python-version: [3.7]
         dotnet: [6.0.x]


### PR DESCRIPTION
Trying out the version of the job here: https://github.com/pulumi/templates/actions/runs/4472575517
