### PR TITLE
Fix kubernetes-java

### DIFF
--- a/kubernetes-java/src/main/java/myproject/App.java
+++ b/kubernetes-java/src/main/java/myproject/App.java
@@ -43,7 +43,7 @@ public class App {
                     .build());
 
             var name = deployment.metadata()
-                .applyValue(m -> m.orElseThrow().name().orElse(""));
+                .applyValue(m -> m.name().orElse(""));
 
             ctx.export("name", name);
         });


### PR DESCRIPTION
This now compiles, where as before it emitted:

```
Error:  [ERROR] COMPILATION ERROR :
Error:  [ERROR] /tmp/test-env1721584717/src/main/java/myproject/App.java:[46,35] cannot find symbol
          symbol:   method orElseThrow()
          location: variable m of type com.pulumi.kubernetes.meta.v1.outputs.ObjectMeta
Error:  [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project test-env1721584717: Compilation failure
Error:  [ERROR] /tmp/test-env1721584717/src/main/java/myproject/App.java:[46,35] cannot find symbol
Error:  [ERROR]   symbol:   method orElseThrow()
Error:  [ERROR]   location: variable m of type com.pulumi.kubernetes.meta.v1.outputs.ObjectMeta
Error:  [ERROR]
Error:  [ERROR] -> [Help 1]
Error:  [ERROR]
Error:  [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  [ERROR] Re-run Maven using the -X switch to enable full debug logging.
Error:  [ERROR]
Error:  [ERROR] For more information about the errors and possible solutions, please read the following articles:
Error:  [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```