### PR TITLE
feat: use engines for all node templates

### DIFF
--- a/alicloud-javascript/package.json
+++ b/alicloud-javascript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.js",
+    "engines": {
+        "node": ">=16"
+    },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/alicloud": "^3.0.0"

--- a/alicloud-typescript/package.json
+++ b/alicloud-typescript/package.json
@@ -4,6 +4,9 @@
     "devDependencies": {
         "@types/node": "^16"
     },
+    "engines": {
+        "node": ">=16"
+    },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/alicloud": "^3.0.0"

--- a/auth0-javascript/package.json
+++ b/auth0-javascript/package.json
@@ -1,6 +1,9 @@
 {
   "name": "${PROJECT}",
   "main": "index.js",
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "@pulumi/pulumi": "^3.20.0",
     "@pulumi/auth0": "^2.3.2"

--- a/auth0-typescript/package.json
+++ b/auth0-typescript/package.json
@@ -1,6 +1,9 @@
 {
   "name": "${PROJECT}",
   "main": "index.ts",
+  "engines": {
+    "node": ">=16"
+  },
   "devDependencies": {
     "@types/node": "^16"
   },

--- a/aws-javascript/package.json
+++ b/aws-javascript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.js",
+    "engines": {
+        "node": ">=16"
+    },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/aws": "^5.0.0",

--- a/aws-native-javascript/package.json
+++ b/aws-native-javascript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.js",
+    "engines": {
+        "node": ">=16"
+    },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/aws-native": "^0.8.0"

--- a/aws-native-typescript/package.json
+++ b/aws-native-typescript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.ts",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/aws-typescript/package.json
+++ b/aws-typescript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.ts",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/azure-classic-javascript/package.json
+++ b/azure-classic-javascript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.js",
+    "engines": {
+        "node": ">=16"
+    },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/azure": "^5.0.0"

--- a/azure-classic-typescript/package.json
+++ b/azure-classic-typescript/package.json
@@ -4,6 +4,9 @@
     "devDependencies": {
         "@types/node": "^16"
     },
+    "engines": {
+        "node": ">=16"
+    },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/azure": "^5.0.0"

--- a/azure-javascript/package.json
+++ b/azure-javascript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.js",
+    "engines": {
+        "node": ">=16"
+    },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/azure-native": "^2.0.0"

--- a/azure-typescript/package.json
+++ b/azure-typescript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.ts",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/civo-javascript/package.json
+++ b/civo-javascript/package.json
@@ -1,6 +1,9 @@
 {
   "name": "${PROJECT}",
   "main": "index.js",
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "@pulumi/pulumi": "3.60.0",
     "@pulumi/civo": "2.3.4"

--- a/civo-typescript/package.json
+++ b/civo-typescript/package.json
@@ -1,6 +1,9 @@
 {
   "name": "${PROJECT}",
   "main": "index.ts",
+  "engines": {
+    "node": ">=16"
+  },
   "devDependencies": {
     "@types/node": "^18"
   },

--- a/container-aws-typescript/package.json
+++ b/container-aws-typescript/package.json
@@ -1,5 +1,8 @@
 {
     "name": "${PROJECT}",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
 	    "@types/node": "^16"
     },

--- a/container-azure-typescript/app/package.json
+++ b/container-azure-typescript/app/package.json
@@ -2,6 +2,9 @@
     "name": "${PROJECT}-app",
     "version": "0.1.0",
     "main": "index.js",
+    "engines": {
+        "node": ">=16"
+    },
     "scripts": {
         "start": "node index.js"
     },

--- a/container-azure-typescript/package.json
+++ b/container-azure-typescript/package.json
@@ -1,5 +1,8 @@
 {
     "name": "${PROJECT}",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/container-gcp-typescript/app/package.json
+++ b/container-gcp-typescript/app/package.json
@@ -2,6 +2,9 @@
     "name": "${PROJECT}-app",
     "version": "0.1.0",
     "main": "index.js",
+    "engines": {
+        "node": ">=16"
+    },
     "scripts": {
         "start": "node index.js"
     },

--- a/container-gcp-typescript/package.json
+++ b/container-gcp-typescript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.ts",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/digitalocean-javascript/package.json
+++ b/digitalocean-javascript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.js",
+    "engines": {
+        "node": ">=16"
+    },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/digitalocean": "^4.0.0"

--- a/digitalocean-typescript/package.json
+++ b/digitalocean-typescript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.ts",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/equinix-metal-javascript/package.json
+++ b/equinix-metal-javascript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.js",
+    "engines": {
+        "node": ">=16"
+    },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/equinix-metal": "^2.0.0"

--- a/equinix-metal-typescript/package.json
+++ b/equinix-metal-typescript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.ts",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/gcp-javascript/package.json
+++ b/gcp-javascript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.js",
+    "engines": {
+        "node": ">=16"
+    },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/gcp": "^6.0.0"

--- a/gcp-typescript/package.json
+++ b/gcp-typescript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.ts",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/github-javascript/package.json
+++ b/github-javascript/package.json
@@ -1,6 +1,9 @@
 {
   "name": "${PROJECT}",
   "main": "index.js",
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "@pulumi/pulumi": "^3.19.0",
     "@pulumi/github": "^4.8.1"

--- a/github-typescript/package.json
+++ b/github-typescript/package.json
@@ -1,6 +1,9 @@
 {
   "name": "${PROJECT}",
   "main": "index.ts",
+  "engines": {
+    "node": ">=16"
+  },
   "devDependencies": {
     "@types/node": "^16"
   },

--- a/google-native-typescript/package.json
+++ b/google-native-typescript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.ts",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/hello-aws-javascript/package.json
+++ b/hello-aws-javascript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.js",
+    "engines": {
+        "node": ">=16"
+    },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/aws": "^5.0.0",

--- a/helm-kubernetes-typescript/package.json
+++ b/helm-kubernetes-typescript/package.json
@@ -1,5 +1,8 @@
 {
     "name": "test",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.js",
+    "engines": {
+        "node": ">=16"
+    },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0"
     }

--- a/kubernetes-aws-typescript/package.json
+++ b/kubernetes-aws-typescript/package.json
@@ -1,5 +1,8 @@
 {
     "name": "${PROJECT}",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/kubernetes-azure-typescript/package.json
+++ b/kubernetes-azure-typescript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.ts",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/kubernetes-gcp-typescript/package.json
+++ b/kubernetes-gcp-typescript/package.json
@@ -1,5 +1,8 @@
 {
   "name": "${PROJECT}",
+  "engines": {
+    "node": ">=16"
+  },
   "devDependencies": {
     "@types/node": "^16"
   },

--- a/kubernetes-javascript/package.json
+++ b/kubernetes-javascript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.js",
+    "engines": {
+        "node": ">=16"
+    },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/kubernetes": "^3.0.0"

--- a/kubernetes-typescript/package.json
+++ b/kubernetes-typescript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.ts",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/linode-javascript/package.json
+++ b/linode-javascript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.js",
+    "engines": {
+        "node": ">=16"
+    },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/linode": "^3.0.0"

--- a/linode-typescript/package.json
+++ b/linode-typescript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.ts",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/oci-javascript/package.json
+++ b/oci-javascript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.js",
+    "engines": {
+        "node": ">=16"
+    },
     "dependencies": {
         "@pulumi/pulumi": "3.60.0",
         "@pulumi/oci": "0.13.0"

--- a/oci-typescript/package.json
+++ b/oci-typescript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.ts",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^18"
     },

--- a/openstack-javascript/package.json
+++ b/openstack-javascript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.js",
+    "engines": {
+        "node": ">=16"
+    },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/openstack": "^3.0.0"

--- a/openstack-typescript/package.json
+++ b/openstack-typescript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.ts",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/random-typescript/package.json
+++ b/random-typescript/package.json
@@ -1,6 +1,9 @@
 {
   "name": "${PROJECT}",
   "main": "index.ts",
+  "engines": {
+    "node": ">=16"
+  },
   "devDependencies": {
     "@types/node": "^14"
   },

--- a/rediscloud-javascript/package.json
+++ b/rediscloud-javascript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "type": "module",
+    "engines": {
+        "node": ">=16"
+    },
     "main": "index.js",
     "dependencies": {
         "@pulumi/pulumi": "3.60.0",

--- a/serverless-aws-typescript/package.json
+++ b/serverless-aws-typescript/package.json
@@ -1,5 +1,8 @@
 {
     "name": "${PROJECT}",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
 	    "@types/node": "^16"
     },

--- a/serverless-azure-typescript/package.json
+++ b/serverless-azure-typescript/package.json
@@ -1,5 +1,8 @@
 {
     "name": "${PROJECT}",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/serverless-gcp-typescript/app/package.json
+++ b/serverless-gcp-typescript/app/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}-app",
     "version": "0.1.0",
+    "engines": {
+        "node": ">=16"
+    },
     "dependencies": {
         "@google-cloud/functions-framework": "^3.1.0"
     }

--- a/serverless-gcp-typescript/package.json
+++ b/serverless-gcp-typescript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.ts",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/static-website-aws-typescript/package.json
+++ b/static-website-aws-typescript/package.json
@@ -1,5 +1,8 @@
 {
     "name": "${PROJECT}",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/static-website-azure-typescript/package.json
+++ b/static-website-azure-typescript/package.json
@@ -1,5 +1,8 @@
 {
     "name": "${PROJECT}",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/static-website-gcp-typescript/package.json
+++ b/static-website-gcp-typescript/package.json
@@ -1,5 +1,8 @@
 {
     "name": "${PROJECT}",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,5 +1,8 @@
 {
     "name": "${PROJECT}",
+    "engines": {
+        "node": ">=16"
+    },
     "main": "index.ts",
     "devDependencies": {
         "@types/node": "^16"

--- a/vm-aws-typescript/package.json
+++ b/vm-aws-typescript/package.json
@@ -1,5 +1,8 @@
 {
     "name": "${PROJECT}",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/vm-azure-typescript/package.json
+++ b/vm-azure-typescript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "vm-azure-typescript",
     "main": "index.ts",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/vm-gcp-typescript/package.json
+++ b/vm-gcp-typescript/package.json
@@ -1,6 +1,9 @@
 {
     "name": "${PROJECT}",
     "main": "index.ts",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },

--- a/webapp-kubernetes-typescript/package.json
+++ b/webapp-kubernetes-typescript/package.json
@@ -1,5 +1,8 @@
 {
     "name": "webapp-kubernetes-typescript",
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/node": "^16"
     },


### PR DESCRIPTION
The benefit of using `"engines"` is that developers are told which version of Node they should use.

Even though the `pulumi/pulumi` package is using `>=8.13.0 || >=10.10.0`, I think pushing developers to at least Node v16 makes sense.

Related: We should consider using Node LTS for all the templates. It's a good practice to use active LTS on new Node projects.