### PR TITLE
chore: bump node to active LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-latest]
         go-version: [1.18.x]
-        node-version: [16.x]
+        node-version: [18.x]
         python-version: [3.7]
         dotnet: [6.0.x]
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-latest]
         go-version: [1.18.x]
-        node-version: [16.x]
+        node-version: [18.x]
         python-version: [3.7]
         dotnet: [6.0.x]
         pulumi-version:

--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest]
         go-version: [1.20.x]
-        node-version: [16.x]
+        node-version: [18.x]
         python-version: [3.7]
         dotnet: [6.0.x]
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, windows-latest]
         go-version: [1.18.x]
-        node-version: [16.x]
+        node-version: [18.x]
         python-version: [3.7]
         dotnet: [6.0.x]
     runs-on: ${{ matrix.platform }}

--- a/aiven-typescript/package.json
+++ b/aiven-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^14"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.20.0",

--- a/alicloud-typescript/package.json
+++ b/alicloud-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/auth0-typescript/package.json
+++ b/auth0-typescript/package.json
@@ -2,7 +2,7 @@
   "name": "${PROJECT}",
   "main": "index.ts",
   "devDependencies": {
-    "@types/node": "^16"
+    "@types/node": "^18"
   },
   "dependencies": {
     "@pulumi/pulumi": "^3.20.0",

--- a/aws-native-typescript/package.json
+++ b/aws-native-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/aws-typescript/package.json
+++ b/aws-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/azure-classic-typescript/package.json
+++ b/azure-classic-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/azure-typescript/package.json
+++ b/azure-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/container-aws-typescript/package.json
+++ b/container-aws-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-	    "@types/node": "^16"
+	    "@types/node": "^18"
     },
     "dependencies": {
 	    "typescript": "^4.0.0",

--- a/container-azure-typescript/package.json
+++ b/container-azure-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/azure-native": "^2.0.0",

--- a/container-gcp-typescript/package.json
+++ b/container-gcp-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/docker": "^4.2.3",

--- a/digitalocean-typescript/package.json
+++ b/digitalocean-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/equinix-metal-typescript/package.json
+++ b/equinix-metal-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/gcp-typescript/package.json
+++ b/gcp-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/github-typescript/package.json
+++ b/github-typescript/package.json
@@ -2,7 +2,7 @@
   "name": "${PROJECT}",
   "main": "index.ts",
   "devDependencies": {
-    "@types/node": "^16"
+    "@types/node": "^18"
   },
   "dependencies": {
     "@pulumi/pulumi": "^3.19.0",

--- a/google-native-typescript/package.json
+++ b/google-native-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.1.0",

--- a/helm-kubernetes-typescript/package.json
+++ b/helm-kubernetes-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "test",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "typescript": "^4.0.0",

--- a/kubernetes-aws-typescript/package.json
+++ b/kubernetes-aws-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "typescript": "^4.0.0",

--- a/kubernetes-azure-typescript/package.json
+++ b/kubernetes-azure-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/kubernetes-gcp-typescript/package.json
+++ b/kubernetes-gcp-typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "${PROJECT}",
   "devDependencies": {
-    "@types/node": "^16"
+    "@types/node": "^18"
   },
   "dependencies": {
     "typescript": "^4.0.0",

--- a/kubernetes-typescript/package.json
+++ b/kubernetes-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/linode-typescript/package.json
+++ b/linode-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/openstack-typescript/package.json
+++ b/openstack-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/random-typescript/package.json
+++ b/random-typescript/package.json
@@ -2,7 +2,7 @@
   "name": "${PROJECT}",
   "main": "index.ts",
   "devDependencies": {
-    "@types/node": "^14"
+    "@types/node": "^18"
   },
   "dependencies": {
     "@pulumi/pulumi": "^3.19.0",

--- a/serverless-aws-typescript/package.json
+++ b/serverless-aws-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-	    "@types/node": "^16"
+	    "@types/node": "^18"
     },
     "dependencies": {
 	    "@pulumi/aws": "^5.23.0",

--- a/serverless-azure-typescript/package.json
+++ b/serverless-azure-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
     "@pulumi/azure-native": "^2.0.0",

--- a/serverless-gcp-typescript/package.json
+++ b/serverless-gcp-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/gcp": "^6.45.0",

--- a/static-website-aws-typescript/package.json
+++ b/static-website-aws-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/aws": "^5.23.0",

--- a/static-website-azure-typescript/package.json
+++ b/static-website-azure-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/azure-native": "^2.0.0",

--- a/static-website-gcp-typescript/package.json
+++ b/static-website-gcp-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/gcp": "^6.45.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0"

--- a/vm-aws-typescript/package.json
+++ b/vm-aws-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "typescript": "^4.0.0",

--- a/vm-azure-typescript/package.json
+++ b/vm-azure-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "vm-azure-typescript",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/azure-native": "^2.0.0",

--- a/vm-gcp-typescript/package.json
+++ b/vm-gcp-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/webapp-kubernetes-typescript/package.json
+++ b/webapp-kubernetes-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "webapp-kubernetes-typescript",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "typescript": "^4.0.0",


### PR DESCRIPTION
Node recommends using Long Term Support (LTS) version for most users. We've kept the template updated to one version behind for quite some time. IMHO, I'm not sure we should be one version behind LTS.

Node has _current_ which is v20 at the time of writing. That feels too unstable for Pulumi templates, but LTS is what is mostly recommended. LTS is kind of _one version behind_ 😊

See the schedule here:
https://github.com/nodejs/release#release-schedule

closes #614 