### PR TITLE
Update the Go verson for Scaleway

### DIFF
--- a/scaleway-go/go.mod
+++ b/scaleway-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.20
+go 1.18
 
 require (
 	github.com/lbrlabs/pulumi-scaleway/sdk v1.7.0


### PR DESCRIPTION
Should be 1.18 to align with our other templates.