### PR TITLE
Increase the size of the Windows runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macOS-latest, windows-latest]
+        platform: [ubuntu-latest, macOS-latest, windows-8core-2022]
         go-version: [1.18.x]
         node-version: [16.x]
         python-version: [3.7]

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,4 +1,4 @@
-name: Run Template Tests Against Latest CLI + Dev CLI
+name: Run Template Tests Against Latest CLI
 on:
   schedule:
     - cron: '0 8 * * *'
@@ -31,15 +31,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macOS-latest, windows-latest]
+        platform: [ubuntu-latest, macOS-latest, windows-8core-2022]
         go-version: [1.18.x]
         node-version: [16.x]
         python-version: [3.7]
         dotnet: [6.0.x]
         pulumi-version:
           - latest
-          # Temporarily commented per https://github.com/pulumi/templates/issues/388.
-          # - dev
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: read

--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest, macOS-latest, windows-8core-2022]
         go-version: [1.18.x]
         node-version: [16.x]
         python-version: [3.7]


### PR DESCRIPTION
This repo's Windows tests have been failing for a while without emitting any log output. I figured this might have something to do with resource exhaustion, so I bumped the Windows runners to the same level we use to build the docs, and [that seems to have worked](https://github.com/pulumi/templates/actions/runs/5765561110), so this PR applies that setting for all of our Windows tests, and also adds macOS to the list where it had been excluded.

Fixes #607.
Fixes #556.