### PR TITLE
Update runner software versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-8core-2022]
-        go-version: [1.18.x]
-        node-version: [16.x]
-        python-version: [3.7]
+        go-version: [1.20.x]
+        node-version: [18.x]
+        python-version: [3.11]
         dotnet: [6.0.x]
     runs-on: ${{ matrix.platform }}
     permissions:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -32,9 +32,9 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-8core-2022]
-        go-version: [1.18.x]
-        node-version: [16.x]
-        python-version: [3.7]
+        go-version: [1.20.x]
+        node-version: [18.x]
+        python-version: [3.11]
         dotnet: [6.0.x]
         pulumi-version:
           - latest

--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -43,9 +43,9 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-8core-2022]
-        go-version: [1.18.x]
-        node-version: [16.x]
-        python-version: [3.7]
+        go-version: [1.20.x]
+        node-version: [18.x]
+        python-version: [3.11]
         dotnet: [6.0.x]
     runs-on: ${{ matrix.platform }}
     permissions:


### PR DESCRIPTION
Update to newer (supported) versions of Go, Node, and Python for tests (attempt to fix #636)