### PR TITLE
Unset the important flag on the SageMaker template

### DIFF
--- a/sagemaker-aws-python/Pulumi.yaml
+++ b/sagemaker-aws-python/Pulumi.yaml
@@ -3,7 +3,6 @@ description: ${DESCRIPTION}
 runtime: python
 template:
   description: A Python program to deploy a Huggingface LLM model to Amazon SageMaker with CloudWatch monitoring
-  important: true
   config:
     aws:region:
       description: The AWS region where resources will be created


### PR DESCRIPTION
We currently only use this flag for our tier-1 templates (e.g., `aws-typescript` and the like). Removing it from this template will also "fix" the [failing tests](https://github.com/pulumi/templates/actions/runs/6127351193/job/16632983679) (i.e., by skipping them).