### PR TITLE
Fix kubernetes-go template

### DIFF
--- a/kubernetes-go/main.go
+++ b/kubernetes-go/main.go
@@ -37,7 +37,7 @@ func main() {
 			return err
 		}
 
-		ctx.Export("name", deployment.Metadata.Elem().Name())
+		ctx.Export("name", deployment.Metadata.Name())
 
 		return nil
 	})


### PR DESCRIPTION
The template uses a method (`deployment.Metadata.Elem()`) which is apparently no longer valid.

Part of https://github.com/pulumi/pulumi-hugo/issues/3354.