### PR TITLE
Update aws-go dependencies

### DIFF
--- a/aws-go/go.mod
+++ b/aws-go/go.mod
@@ -1,8 +1,8 @@
 module ${PROJECT}
 
-go 1.18
+go 1.20
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.0.2
-	github.com/pulumi/pulumi/sdk/v3 v3.78.1
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.2.0
+	github.com/pulumi/pulumi/sdk/v3 v3.84.0
 )


### PR DESCRIPTION
It looks like the [PRs](https://github.com/pulumi/templates/pulls) that automatically update Go dependencies haven't been merged in a while.

To make it easier to get started [trying the Go generics preview](https://www.pulumi.com/blog/go-generics-preview/#migrating-an-aws-program-to-leverage-go-generics), update the dependencies for the aws-go template to the latest versions, along with the Go 1.20 ([one version behind current](https://go.dev/doc/devel/release#policy)). That way, users trying out generics, only have to update the `pulumi-aws` dependency to the preview branch, and don't have to update the core Pulumi SDK to a more recent version.

Subsequently, all the go templates should be updated.