### PR TITLE
Revert serverless-aws-go with apigateway program to aws v5

### DIFF
--- a/serverless-aws-go/go.mod
+++ b/serverless-aws-go/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/pulumi/pulumi-aws-apigateway/sdk v1.0.1
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.0.2
+	github.com/pulumi/pulumi-aws/sdk/v5 v5.42.0
 	github.com/pulumi/pulumi/sdk/v3 v3.49.0
 )
 

--- a/serverless-aws-go/main.go
+++ b/serverless-aws-go/main.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 
 	"github.com/pulumi/pulumi-aws-apigateway/sdk/go/apigateway"
-	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam"
-	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/lambda"
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/iam"
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lambda"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 


### PR DESCRIPTION
apigateway v1 and aws v6 are currently incompatible. The apigateway v2 release will be compatible with aws v6.