### PR TITLE
Update generate-go-mod.sh to compute go.mod/go.sum

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+export GOTOOLCHAIN=go1.20.10

--- a/.github/workflows/update-templates.yml
+++ b/.github/workflows/update-templates.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Go
         uses: actions/setup-go@v4
+        with:
+          go-version: "1.20.10"
       - name: Update Template Versions
         run: |
           cd generator

--- a/.github/workflows/update-templates.yml
+++ b/.github/workflows/update-templates.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v4
       - name: Update Template Versions
         run: |
           cd generator

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ traces
 package-lock.json
 yarn.lock
 !/yarn.lock
-go.sum
 !tests/go.sum
 Pulumi.*.yaml
 node_modules


### PR DESCRIPTION
This updates the script responsible for bumping packages in `go.mod` to also run `go mod tidy` along the way. This ensures that the projects we template are usable out-of-the-box without requiring the user to run `go mod tidy` themselves.

`go mod tidy` can't parse `go.mod` files of the form `module ${PACKAGE}`, so we temporarily re-write `${PACKAGE}`, perform the tidy, and then restore `${PACKAGE}`.

Refs https://github.com/pulumi/pulumi-cloud-requests/issues/312 
Refs https://github.com/pulumi/templates/issues/114