### PR TITLE
Update Kubernetes on AWS (EKS) templates

### DIFF
--- a/kubernetes-aws-csharp/Program.cs
+++ b/kubernetes-aws-csharp/Program.cs
@@ -41,9 +41,9 @@ return await Deployment.RunAsync(() =>
         // Do not give the worker nodes public IP addresses
         NodeAssociatePublicIpAddress = false,
 
-        // Uncomment the next two lines for a private cluster (VPN access required)
-        // EndpointPrivateAccess = true,
-        // EndpointPublicAccess = false,
+        // Change these values for a private cluster (VPN access required)
+        EndpointPrivateAccess = false,
+        EndpointPublicAccess = true,
     });
 
     // Export some values for use elsewhere

--- a/kubernetes-aws-go/go.mod
+++ b/kubernetes-aws-go/go.mod
@@ -3,9 +3,9 @@ module ${PROJECT}
 go 1.20
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk v1.0.0
-	github.com/pulumi/pulumi-eks/sdk v0.41.0
-	github.com/pulumi/pulumi/sdk/v3 v3.31.1
+	github.com/pulumi/pulumi-awsx/sdk v1.0.6
+	github.com/pulumi/pulumi-eks/sdk v1.0.3
+	github.com/pulumi/pulumi/sdk/v3 v3.81.0
 )
 
 require (

--- a/kubernetes-aws-go/main.go
+++ b/kubernetes-aws-go/main.go
@@ -42,6 +42,7 @@ func main() {
 		}
 
 		// Create a new EKS cluster
+		f := false
 		eksCluster, err := eks.NewCluster(ctx, "eks-cluster", &eks.ClusterArgs{
 			// Put the cluster in the new VPC created earlier
 			VpcId: eksVpc.VpcId,
@@ -55,10 +56,10 @@ func main() {
 			MinSize:         pulumi.Int(minClusterSize),
 			MaxSize:         pulumi.Int(maxClusterSize),
 			// Do not give the worker nodes a public IP address
-			NodeAssociatePublicIpAddress: pulumi.Bool(false),
-			// Uncomment the next two lines for a private cluster (VPN access required)
-			// EndpointPrivateAccess: 	      pulumi.Bool(true),
-			// EndpointPublicAccess:         pulumi.Bool(false),
+			NodeAssociatePublicIpAddress: &f,
+			// Change these values for a private cluster (VPN access required)
+			EndpointPrivateAccess: pulumi.Bool(false),
+			EndpointPublicAccess:  pulumi.Bool(true),
 		})
 		if err != nil {
 			return err

--- a/kubernetes-aws-python/__main__.py
+++ b/kubernetes-aws-python/__main__.py
@@ -30,9 +30,9 @@ eks_cluster = eks.Cluster("eks-cluster",
     max_size=max_cluster_size,
     # Do not give worker nodes a public IP address
     node_associate_public_ip_address=False,
-    # Uncomment the next two lines for private cluster (VPN access required)
-    # endpoint_private_access=true,
-    # endpoint_public_access=false
+    # Change these values for a private cluster (VPN access required)
+    endpoint_private_access=False,
+    endpoint_public_access=True
     )
 
 # Export values to use elsewhere

--- a/kubernetes-aws-typescript/index.ts
+++ b/kubernetes-aws-typescript/index.ts
@@ -31,9 +31,9 @@ const eksCluster = new eks.Cluster("eks-cluster", {
     maxSize: maxClusterSize,
     // Do not give the worker nodes public IP addresses
     nodeAssociatePublicIpAddress: false,
-    // Uncomment the next two lines for a private cluster (VPN access required)
-    // endpointPrivateAccess: true,
-    // endpointPublicAccess: false
+    // Change these values for a private cluster (VPN access required)
+    endpointPrivateAccess: false,
+    endpointPublicAccess: true,
 });
 
 // Export some values for use elsewhere

--- a/kubernetes-aws-yaml/Pulumi.yaml
+++ b/kubernetes-aws-yaml/Pulumi.yaml
@@ -62,9 +62,9 @@ resources:
       maxSize: ${maxClusterSize}
       # Do not give the worker nodes public IP addresses
       nodeAssociatePublicIpAddress: false
-      # Uncomment next two lines for private cluster access (VPN access required)
-      # endpointPrivateAccess: true
-      # endpointPublicAccess: false
+      # Change these values for a private cluster (VPN access required)
+      endpointPrivateAccess: false
+      endpointPublicAccess: true
 outputs:
   # Output the Kubeconfig for the cluster
   kubeconfig: ${eks-cluster.kubeconfig}


### PR DESCRIPTION
Update all Kubernetes on AWS (EKS) templates to use EKS >1.0 Update configuration values for private clusters for improved clarity

Fixes broken Go template

Closes #664