### PR TITLE
Update pulumi-gcp to v7.0.0

### DIFF
--- a/container-gcp-csharp/${PROJECT}.csproj
+++ b/container-gcp-csharp/${PROJECT}.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Pulumi" Version="3.*" />
-        <PackageReference Include="Pulumi.Gcp" Version="6.*" />
+        <PackageReference Include="Pulumi.Gcp" Version="7.0.0-alpha.0" />
         <PackageReference Include="Pulumi.Docker" Version="4.*" />
         <PackageReference Include="Pulumi.Random" Version="4.*" />
     </ItemGroup>

--- a/container-gcp-csharp/${PROJECT}.csproj
+++ b/container-gcp-csharp/${PROJECT}.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Pulumi" Version="3.*" />
-        <PackageReference Include="Pulumi.Gcp" Version="7.0.0-rc.0" />
+        <PackageReference Include="Pulumi.Gcp" Version="7.*" />
         <PackageReference Include="Pulumi.Docker" Version="4.*" />
         <PackageReference Include="Pulumi.Random" Version="4.*" />
     </ItemGroup>

--- a/container-gcp-csharp/${PROJECT}.csproj
+++ b/container-gcp-csharp/${PROJECT}.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Pulumi" Version="3.*" />
-        <PackageReference Include="Pulumi.Gcp" Version="7.0.0-alpha.0" />
+        <PackageReference Include="Pulumi.Gcp" Version="7.0.0-rc.0" />
         <PackageReference Include="Pulumi.Docker" Version="4.*" />
         <PackageReference Include="Pulumi.Random" Version="4.*" />
     </ItemGroup>

--- a/container-gcp-go/go.mod
+++ b/container-gcp-go/go.mod
@@ -3,9 +3,9 @@ module ${PROJECT}
 go 1.20
 
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v6 v6.59.0
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-alpha.0
 	github.com/pulumi/pulumi-random/sdk/v4 v4.13.2
-	github.com/pulumi/pulumi/sdk/v3 v3.74.0
+	github.com/pulumi/pulumi/sdk/v3 v3.86.0
 )
 
 require (
@@ -13,18 +13,31 @@ require (
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
 	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/charmbracelet/bubbles v0.16.1 // indirect
+	github.com/charmbracelet/bubbletea v0.24.2 // indirect
+	github.com/charmbracelet/lipgloss v0.7.1 // indirect
+	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.4.0 // indirect
 	github.com/go-git/go-git/v5 v5.6.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/hashicorp/hcl/v2 v2.16.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.18 // indirect
+	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
+	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/muesli/reflow v0.3.0 // indirect
+	github.com/muesli/termenv v0.15.1 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
@@ -36,13 +49,15 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/zclconf/go-cty v1.12.1 // indirect
 	golang.org/x/crypto v0.7.0 // indirect
-	golang.org/x/net v0.8.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/term v0.6.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
+	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
+	golang.org/x/term v0.8.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
-	google.golang.org/grpc v1.53.0 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
+	google.golang.org/grpc v1.57.0 // indirect
+	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/frand v1.4.2 // indirect
@@ -55,7 +70,7 @@ require (
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/djherbis/times v1.5.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
-	github.com/golang/glog v1.0.0 // indirect
+	github.com/golang/glog v1.1.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
@@ -75,6 +90,5 @@ require (
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/mod v0.10.0 // indirect
-	google.golang.org/genproto v0.0.0-20230303212802-e74f57abe488 // indirect
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600 // indirect
 )

--- a/container-gcp-go/go.mod
+++ b/container-gcp-go/go.mod
@@ -2,8 +2,6 @@ module ${PROJECT}
 
 go 1.21
 
-toolchain go1.21.3
-
 require (
 	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0
 	github.com/pulumi/pulumi-random/sdk/v4 v4.13.2

--- a/container-gcp-go/go.mod
+++ b/container-gcp-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.21
+go 1.20
 
 require (
 	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0

--- a/container-gcp-go/go.mod
+++ b/container-gcp-go/go.mod
@@ -3,7 +3,7 @@ module ${PROJECT}
 go 1.20
 
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0
 	github.com/pulumi/pulumi-random/sdk/v4 v4.13.2
 	github.com/pulumi/pulumi/sdk/v3 v3.91.1
 )

--- a/container-gcp-go/go.mod
+++ b/container-gcp-go/go.mod
@@ -1,17 +1,19 @@
 module ${PROJECT}
 
-go 1.20
+go 1.21
+
+toolchain go1.21.3
 
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-alpha.0
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0
 	github.com/pulumi/pulumi-random/sdk/v4 v4.13.2
-	github.com/pulumi/pulumi/sdk/v3 v3.86.0
+	github.com/pulumi/pulumi/sdk/v3 v3.91.1
 )
 
 require (
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
-	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
@@ -26,14 +28,14 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
-	github.com/hashicorp/hcl/v2 v2.16.1 // indirect
-	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/hashicorp/hcl/v2 v2.17.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
-	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
@@ -41,20 +43,22 @@ require (
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
+	github.com/pulumi/esc v0.5.6 // indirect
 	github.com/skeema/knownhosts v1.1.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	github.com/zclconf/go-cty v1.12.1 // indirect
-	golang.org/x/crypto v0.7.0 // indirect
-	golang.org/x/net v0.10.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.8.0 // indirect
-	golang.org/x/term v0.8.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
-	golang.org/x/tools v0.6.0 // indirect
+	github.com/zclconf/go-cty v1.13.2 // indirect
+	golang.org/x/crypto v0.14.0 // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
+	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/sync v0.4.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/term v0.13.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
+	golang.org/x/tools v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
 	google.golang.org/grpc v1.57.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
@@ -80,15 +84,15 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pulumi/pulumi-docker/sdk/v4 v4.2.3
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.1 // indirect
-	github.com/sergi/go-diff v1.2.0 // indirect
-	github.com/spf13/cobra v1.6.1 // indirect
+	github.com/sergi/go-diff v1.3.1 // indirect
+	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	go.uber.org/atomic v1.10.0 // indirect
-	golang.org/x/mod v0.10.0 // indirect
+	golang.org/x/mod v0.13.0 // indirect
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600 // indirect
 )

--- a/container-gcp-go/main.go
+++ b/container-gcp-go/main.go
@@ -4,8 +4,8 @@ import (
 	"strconv"
 
 	"github.com/pulumi/pulumi-docker/sdk/v4/go/docker"
-	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/artifactregistry"
-	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/cloudrun"
+	"github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/artifactregistry"
+	"github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/cloudrun"
 	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"

--- a/container-gcp-python/requirements.txt
+++ b/container-gcp-python/requirements.txt
@@ -1,4 +1,4 @@
 pulumi>=3.0.0,<4.0.0
-pulumi-gcp>=6.0.0,<7.0.0
+pulumi-gcp==7.0.0a0
 pulumi-docker>=4.0.0,<5.0.0
 pulumi-random >=4.0.0,<5.0.0

--- a/container-gcp-python/requirements.txt
+++ b/container-gcp-python/requirements.txt
@@ -1,4 +1,4 @@
 pulumi>=3.0.0,<4.0.0
-pulumi-gcp==7.0.0rc0
+pulumi-gcp>=7.0.0,<8.0.0
 pulumi-docker>=4.0.0,<5.0.0
 pulumi-random >=4.0.0,<5.0.0

--- a/container-gcp-python/requirements.txt
+++ b/container-gcp-python/requirements.txt
@@ -1,4 +1,4 @@
 pulumi>=3.0.0,<4.0.0
-pulumi-gcp==7.0.0a0
+pulumi-gcp==7.0.0rc0
 pulumi-docker>=4.0.0,<5.0.0
 pulumi-random >=4.0.0,<5.0.0

--- a/container-gcp-typescript/package.json
+++ b/container-gcp-typescript/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/docker": "^4.2.3",
-        "@pulumi/gcp": "7.0.0-rc.0",
+        "@pulumi/gcp": "^7.0.0",
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/random": "^4.0.0"
     }

--- a/container-gcp-typescript/package.json
+++ b/container-gcp-typescript/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/docker": "^4.2.3",
-        "@pulumi/gcp": "7.0.0-alpha.0",
+        "@pulumi/gcp": "7.0.0-rc.0",
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/random": "^4.0.0"
     }

--- a/container-gcp-typescript/package.json
+++ b/container-gcp-typescript/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/docker": "^4.2.3",
-        "@pulumi/gcp": "^6.0.0",
+        "@pulumi/gcp": "7.0.0-alpha.0",
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/random": "^4.0.0"
     }

--- a/gcp-csharp/${PROJECT}.csproj
+++ b/gcp-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.Gcp" Version="7.0.0-rc.0" />
+    <PackageReference Include="Pulumi.Gcp" Version="7.*" />
   </ItemGroup>
 
 </Project>

--- a/gcp-csharp/${PROJECT}.csproj
+++ b/gcp-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.Gcp" Version="7.0.0-alpha.0" />
+    <PackageReference Include="Pulumi.Gcp" Version="7.0.0-rc.0" />
   </ItemGroup>
 
 </Project>

--- a/gcp-csharp/${PROJECT}.csproj
+++ b/gcp-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.Gcp" Version="6.*" />
+    <PackageReference Include="Pulumi.Gcp" Version="7.0.0-alpha.0" />
   </ItemGroup>
 
 </Project>

--- a/gcp-fsharp/${PROJECT}.fsproj
+++ b/gcp-fsharp/${PROJECT}.fsproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.FSharp" Version="3.*" />
-    <PackageReference Include="Pulumi.Gcp" Version="7.0.0-rc.0" />
+    <PackageReference Include="Pulumi.Gcp" Version="7.*" />
   </ItemGroup>
 
 </Project>

--- a/gcp-fsharp/${PROJECT}.fsproj
+++ b/gcp-fsharp/${PROJECT}.fsproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.FSharp" Version="3.*" />
-    <PackageReference Include="Pulumi.Gcp" Version="6.*" />
+    <PackageReference Include="Pulumi.Gcp" Version="7.0.0-alpha.0" />
   </ItemGroup>
 
 </Project>

--- a/gcp-fsharp/${PROJECT}.fsproj
+++ b/gcp-fsharp/${PROJECT}.fsproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.FSharp" Version="3.*" />
-    <PackageReference Include="Pulumi.Gcp" Version="7.0.0-alpha.0" />
+    <PackageReference Include="Pulumi.Gcp" Version="7.0.0-rc.0" />
   </ItemGroup>
 
 </Project>

--- a/gcp-go/go.mod
+++ b/gcp-go/go.mod
@@ -1,10 +1,12 @@
 module ${PROJECT}
 
-go 1.20
+go 1.21
+
+toolchain go1.21.3
 
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-alpha.0
-	github.com/pulumi/pulumi/sdk/v3 v3.86.0
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0
+	github.com/pulumi/pulumi/sdk/v3 v3.91.1
 )
 
 require (
@@ -12,7 +14,7 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
-	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
@@ -34,9 +36,9 @@ require (
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/hcl/v2 v2.16.1 // indirect
+	github.com/hashicorp/hcl/v2 v2.17.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
-	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
@@ -44,7 +46,7 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
-	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
@@ -54,27 +56,29 @@ require (
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
+	github.com/pulumi/esc v0.5.6 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
-	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/skeema/knownhosts v1.1.0 // indirect
-	github.com/spf13/cobra v1.6.1 // indirect
+	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	github.com/zclconf/go-cty v1.12.1 // indirect
+	github.com/zclconf/go-cty v1.13.2 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a // indirect
-	golang.org/x/net v0.10.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.8.0 // indirect
-	golang.org/x/term v0.8.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
+	golang.org/x/crypto v0.14.0 // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
+	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/sync v0.2.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/term v0.13.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
 	google.golang.org/grpc v1.57.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect

--- a/gcp-go/go.mod
+++ b/gcp-go/go.mod
@@ -3,6 +3,83 @@ module ${PROJECT}
 go 1.20
 
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v6 v6.66.0
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-alpha.0
 	github.com/pulumi/pulumi/sdk/v3 v3.86.0
+)
+
+require (
+	github.com/Microsoft/go-winio v0.5.2 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
+	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
+	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/charmbracelet/bubbles v0.16.1 // indirect
+	github.com/charmbracelet/bubbletea v0.24.2 // indirect
+	github.com/charmbracelet/lipgloss v0.7.1 // indirect
+	github.com/cheggaaa/pb v1.0.29 // indirect
+	github.com/cloudflare/circl v1.3.3 // indirect
+	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
+	github.com/djherbis/times v1.5.0 // indirect
+	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.4.0 // indirect
+	github.com/go-git/go-git/v5 v5.6.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/glog v1.1.0 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/hcl/v2 v2.16.1 // indirect
+	github.com/imdario/mergo v0.3.13 // indirect
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/kevinburke/ssh_config v1.2.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.18 // indirect
+	github.com/mattn/go-localereader v0.0.1 // indirect
+	github.com/mattn/go-runewidth v0.0.14 // indirect
+	github.com/mitchellh/go-ps v1.0.0 // indirect
+	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
+	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/muesli/reflow v0.3.0 // indirect
+	github.com/muesli/termenv v0.15.1 // indirect
+	github.com/opentracing/basictracer-go v1.1.0 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pjbgf/sha1cd v0.3.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/term v1.1.0 // indirect
+	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
+	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/skeema/knownhosts v1.1.0 // indirect
+	github.com/spf13/cobra v1.6.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
+	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
+	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
+	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
+	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/zclconf/go-cty v1.12.1 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
+	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a // indirect
+	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
+	golang.org/x/term v0.8.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
+	google.golang.org/grpc v1.57.0 // indirect
+	google.golang.org/protobuf v1.31.0 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	lukechampine.com/frand v1.4.2 // indirect
+	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600 // indirect
 )

--- a/gcp-go/go.mod
+++ b/gcp-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.21
+go 1.20
 
 require (
 	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0

--- a/gcp-go/go.mod
+++ b/gcp-go/go.mod
@@ -3,7 +3,7 @@ module ${PROJECT}
 go 1.20
 
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0
 	github.com/pulumi/pulumi/sdk/v3 v3.91.1
 )
 

--- a/gcp-go/go.mod
+++ b/gcp-go/go.mod
@@ -2,8 +2,6 @@ module ${PROJECT}
 
 go 1.21
 
-toolchain go1.21.3
-
 require (
 	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0
 	github.com/pulumi/pulumi/sdk/v3 v3.91.1

--- a/gcp-go/main.go
+++ b/gcp-go/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/storage"
+	"github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/storage"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/gcp-java/pom.xml
+++ b/gcp-java/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.pulumi</groupId>
             <artifactId>gcp</artifactId>
-            <version>7.0.0-rc.0</version>
+            <version>(,8.0.0]</version>
         </dependency>
     </dependencies>
 

--- a/gcp-java/pom.xml
+++ b/gcp-java/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.pulumi</groupId>
             <artifactId>gcp</artifactId>
-            <version>(,7.0.0]</version>
+            <version>7.0.0-rc.0</version>
         </dependency>
     </dependencies>
 

--- a/gcp-javascript/package.json
+++ b/gcp-javascript/package.json
@@ -3,6 +3,6 @@
     "main": "index.js",
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/gcp": "7.0.0-rc.0"
+        "@pulumi/gcp": "^7.0.0"
     }
 }

--- a/gcp-javascript/package.json
+++ b/gcp-javascript/package.json
@@ -3,6 +3,6 @@
     "main": "index.js",
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/gcp": "7.0.0-alpha.0"
+        "@pulumi/gcp": "7.0.0-rc.0"
     }
 }

--- a/gcp-javascript/package.json
+++ b/gcp-javascript/package.json
@@ -3,6 +3,6 @@
     "main": "index.js",
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/gcp": "^6.0.0"
+        "@pulumi/gcp": "7.0.0-alpha.0"
     }
 }

--- a/gcp-python/requirements.txt
+++ b/gcp-python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi-gcp>=6.0.0,<7.0.0
+pulumi-gcp==7.0.0a0

--- a/gcp-python/requirements.txt
+++ b/gcp-python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi-gcp==7.0.0rc0
+pulumi-gcp>=7.0.0,<8.0.0

--- a/gcp-python/requirements.txt
+++ b/gcp-python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi-gcp==7.0.0a0
+pulumi-gcp==7.0.0rc0

--- a/gcp-typescript/package.json
+++ b/gcp-typescript/package.json
@@ -6,6 +6,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/gcp": "7.0.0-rc.0"
+        "@pulumi/gcp": "^7.0.0"
     }
 }

--- a/gcp-typescript/package.json
+++ b/gcp-typescript/package.json
@@ -6,6 +6,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/gcp": "^6.0.0"
+        "@pulumi/gcp": "7.0.0-alpha.0"
     }
 }

--- a/gcp-typescript/package.json
+++ b/gcp-typescript/package.json
@@ -6,6 +6,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/gcp": "7.0.0-alpha.0"
+        "@pulumi/gcp": "7.0.0-rc.0"
     }
 }

--- a/gcp-visualbasic/${PROJECT}.vbproj
+++ b/gcp-visualbasic/${PROJECT}.vbproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.Gcp" Version="6.*" />
+    <PackageReference Include="Pulumi.Gcp" Version="7.0.0-alpha.0" />
   </ItemGroup>
 
 </Project>

--- a/gcp-visualbasic/${PROJECT}.vbproj
+++ b/gcp-visualbasic/${PROJECT}.vbproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.Gcp" Version="7.0.0-alpha.0" />
+    <PackageReference Include="Pulumi.Gcp" Version="7.0.0-rc.0" />
   </ItemGroup>
 
 </Project>

--- a/gcp-visualbasic/${PROJECT}.vbproj
+++ b/gcp-visualbasic/${PROJECT}.vbproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.Gcp" Version="7.0.0-rc.0" />
+    <PackageReference Include="Pulumi.Gcp" Version="7.*" />
   </ItemGroup>
 
 </Project>

--- a/gcp-yaml/Pulumi.yaml
+++ b/gcp-yaml/Pulumi.yaml
@@ -14,7 +14,8 @@ resources:
     type: gcp:storage:Bucket
     properties:
       location: US
-    version: v7.0.0-rc.0
+    options:
+      version: v7.0.0-rc.0
 
 outputs:
   # Export the DNS name of the bucket

--- a/gcp-yaml/Pulumi.yaml
+++ b/gcp-yaml/Pulumi.yaml
@@ -14,8 +14,6 @@ resources:
     type: gcp:storage:Bucket
     properties:
       location: US
-    options:
-      version: v7.0.0-rc.0
 
 outputs:
   # Export the DNS name of the bucket

--- a/gcp-yaml/Pulumi.yaml
+++ b/gcp-yaml/Pulumi.yaml
@@ -14,6 +14,7 @@ resources:
     type: gcp:storage:Bucket
     properties:
       location: US
+    version: v7.0.0-rc.0
 
 outputs:
   # Export the DNS name of the bucket

--- a/kubernetes-gcp-csharp/${PROJECT}.csproj
+++ b/kubernetes-gcp-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Gcp" Version="7.0.0-alpha.0" />
+		<PackageReference Include="Pulumi.Gcp" Version="7.0.0-rc.0" />
 	</ItemGroup>
 
 </Project>

--- a/kubernetes-gcp-csharp/${PROJECT}.csproj
+++ b/kubernetes-gcp-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Gcp" Version="6.*" />
+		<PackageReference Include="Pulumi.Gcp" Version="7.0.0-alpha.0" />
 	</ItemGroup>
 
 </Project>

--- a/kubernetes-gcp-csharp/${PROJECT}.csproj
+++ b/kubernetes-gcp-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
-		<PackageReference Include="Pulumi.Gcp" Version="7.0.0-rc.0" />
+		<PackageReference Include="Pulumi.Gcp" Version="7.*" />
 	</ItemGroup>
 
 </Project>

--- a/kubernetes-gcp-go/go.mod
+++ b/kubernetes-gcp-go/go.mod
@@ -2,10 +2,8 @@ module ${PROJECT}
 
 go 1.20
 
-
-
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0
 	github.com/pulumi/pulumi/sdk/v3 v3.91.1
 )
 

--- a/kubernetes-gcp-go/go.mod
+++ b/kubernetes-gcp-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.21
+go 1.20
 
 
 

--- a/kubernetes-gcp-go/go.mod
+++ b/kubernetes-gcp-go/go.mod
@@ -1,10 +1,12 @@
 module ${PROJECT}
 
-go 1.20
+go 1.21
+
+toolchain go1.21.3
 
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-alpha.0
-	github.com/pulumi/pulumi/sdk/v3 v3.86.0
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0
+	github.com/pulumi/pulumi/sdk/v3 v3.91.1
 )
 
 require (
@@ -12,7 +14,7 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
-	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
@@ -34,9 +36,9 @@ require (
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/hcl/v2 v2.16.1 // indirect
+	github.com/hashicorp/hcl/v2 v2.17.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
-	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
@@ -44,7 +46,7 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
-	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
@@ -54,14 +56,15 @@ require (
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
+	github.com/pulumi/esc v0.5.6 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
-	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/skeema/knownhosts v1.1.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
-	github.com/spf13/cobra v1.6.1 // indirect
+	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
@@ -69,14 +72,15 @@ require (
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	github.com/zclconf/go-cty v1.12.1 // indirect
+	github.com/zclconf/go-cty v1.13.2 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a // indirect
-	golang.org/x/net v0.10.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.8.0 // indirect
-	golang.org/x/term v0.8.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
+	golang.org/x/crypto v0.14.0 // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
+	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/sync v0.2.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/term v0.13.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
 	google.golang.org/grpc v1.57.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect

--- a/kubernetes-gcp-go/go.mod
+++ b/kubernetes-gcp-go/go.mod
@@ -3,6 +3,85 @@ module ${PROJECT}
 go 1.20
 
 require (
-	github.com/pulumi/pulumi/sdk/v3 v3.30.0
-	github.com/pulumi/pulumi-gcp/sdk/v6 v6.39.0
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-alpha.0
+	github.com/pulumi/pulumi/sdk/v3 v3.86.0
+)
+
+require (
+	github.com/Microsoft/go-winio v0.5.2 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
+	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
+	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/charmbracelet/bubbles v0.16.1 // indirect
+	github.com/charmbracelet/bubbletea v0.24.2 // indirect
+	github.com/charmbracelet/lipgloss v0.7.1 // indirect
+	github.com/cheggaaa/pb v1.0.29 // indirect
+	github.com/cloudflare/circl v1.3.3 // indirect
+	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
+	github.com/djherbis/times v1.5.0 // indirect
+	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.4.0 // indirect
+	github.com/go-git/go-git/v5 v5.6.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/glog v1.1.0 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/hcl/v2 v2.16.1 // indirect
+	github.com/imdario/mergo v0.3.13 // indirect
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/kevinburke/ssh_config v1.2.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.18 // indirect
+	github.com/mattn/go-localereader v0.0.1 // indirect
+	github.com/mattn/go-runewidth v0.0.14 // indirect
+	github.com/mitchellh/go-ps v1.0.0 // indirect
+	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
+	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/muesli/reflow v0.3.0 // indirect
+	github.com/muesli/termenv v0.15.1 // indirect
+	github.com/opentracing/basictracer-go v1.1.0 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pjbgf/sha1cd v0.3.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/term v1.1.0 // indirect
+	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
+	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/skeema/knownhosts v1.1.0 // indirect
+	github.com/spf13/cast v1.4.1 // indirect
+	github.com/spf13/cobra v1.6.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
+	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
+	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
+	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
+	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/zclconf/go-cty v1.12.1 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
+	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a // indirect
+	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
+	golang.org/x/term v0.8.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
+	google.golang.org/grpc v1.57.0 // indirect
+	google.golang.org/protobuf v1.31.0 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	lukechampine.com/frand v1.4.2 // indirect
+	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600 // indirect
 )

--- a/kubernetes-gcp-go/go.mod
+++ b/kubernetes-gcp-go/go.mod
@@ -2,7 +2,7 @@ module ${PROJECT}
 
 go 1.21
 
-toolchain go1.21.3
+
 
 require (
 	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0

--- a/kubernetes-gcp-go/main.go
+++ b/kubernetes-gcp-go/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/compute"
-	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/container"
-	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/serviceaccount"
+	"github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/compute"
+	"github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/container"
+	"github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/serviceaccount"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )

--- a/kubernetes-gcp-typescript/package.json
+++ b/kubernetes-gcp-typescript/package.json
@@ -6,6 +6,6 @@
   "dependencies": {
     "typescript": "^4.0.0",
     "@pulumi/pulumi": "^3.0.0",
-    "@pulumi/gcp": "6.39.0"
+    "@pulumi/gcp": "7.0.0-alpha.0"
   }
 }

--- a/kubernetes-gcp-typescript/package.json
+++ b/kubernetes-gcp-typescript/package.json
@@ -6,6 +6,6 @@
   "dependencies": {
     "typescript": "^4.0.0",
     "@pulumi/pulumi": "^3.0.0",
-    "@pulumi/gcp": "7.0.0-rc.0"
+    "@pulumi/gcp": "^7.0.0"
   }
 }

--- a/kubernetes-gcp-typescript/package.json
+++ b/kubernetes-gcp-typescript/package.json
@@ -6,6 +6,6 @@
   "dependencies": {
     "typescript": "^4.0.0",
     "@pulumi/pulumi": "^3.0.0",
-    "@pulumi/gcp": "7.0.0-alpha.0"
+    "@pulumi/gcp": "7.0.0-rc.0"
   }
 }

--- a/serverless-gcp-csharp/${PROJECT}.csproj
+++ b/serverless-gcp-csharp/${PROJECT}.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Pulumi" Version="3.*" />
-        <PackageReference Include="Pulumi.Gcp" Version="6.*" />
+        <PackageReference Include="Pulumi.Gcp" Version="7.0.0-alpha.0" />
         <PackageReference Include="Pulumi.SyncedFolder" Version="0.*" />
     </ItemGroup>
 </Project>

--- a/serverless-gcp-csharp/${PROJECT}.csproj
+++ b/serverless-gcp-csharp/${PROJECT}.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Pulumi" Version="3.*" />
-        <PackageReference Include="Pulumi.Gcp" Version="7.0.0-rc.0" />
+        <PackageReference Include="Pulumi.Gcp" Version="7.*" />
         <PackageReference Include="Pulumi.SyncedFolder" Version="0.*" />
     </ItemGroup>
 </Project>

--- a/serverless-gcp-csharp/${PROJECT}.csproj
+++ b/serverless-gcp-csharp/${PROJECT}.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Pulumi" Version="3.*" />
-        <PackageReference Include="Pulumi.Gcp" Version="7.0.0-alpha.0" />
+        <PackageReference Include="Pulumi.Gcp" Version="7.0.0-rc.0" />
         <PackageReference Include="Pulumi.SyncedFolder" Version="0.*" />
     </ItemGroup>
 </Project>

--- a/serverless-gcp-go/go.mod
+++ b/serverless-gcp-go/go.mod
@@ -3,72 +3,88 @@ module ${PROJECT}
 go 1.20
 
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v6 v6.45.0
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-alpha.0
 	github.com/pulumi/pulumi-synced-folder/sdk v0.0.9
-	github.com/pulumi/pulumi/sdk/v3 v3.49.0
+	github.com/pulumi/pulumi/sdk/v3 v3.86.0
 )
 
 require (
-	github.com/HdrHistogram/hdrhistogram-go v1.1.2 // indirect
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
+	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/charmbracelet/bubbles v0.16.1 // indirect
+	github.com/charmbracelet/bubbletea v0.24.2 // indirect
+	github.com/charmbracelet/lipgloss v0.7.1 // indirect
 	github.com/cheggaaa/pb v1.0.29 // indirect
-	github.com/cloudflare/circl v1.1.0 // indirect
+	github.com/cloudflare/circl v1.3.3 // indirect
+	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
 	github.com/djherbis/times v1.5.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
-	github.com/go-git/go-billy/v5 v5.3.1 // indirect
-	github.com/go-git/go-git/v5 v5.5.1 // indirect
-	github.com/gofrs/uuid v3.3.0+incompatible // indirect
+	github.com/go-git/go-billy/v5 v5.4.0 // indirect
+	github.com/go-git/go-git/v5 v5.6.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/glog v1.0.0 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/glog v1.1.0 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/hcl/v2 v2.16.1 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
-	github.com/mattn/go-runewidth v0.0.8 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.18 // indirect
+	github.com/mattn/go-localereader v0.0.1 // indirect
+	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
+	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
+	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/muesli/reflow v0.3.0 // indirect
+	github.com/muesli/termenv v0.15.1 // indirect
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
-	github.com/opentracing/opentracing-go v1.1.0 // indirect
-	github.com/pjbgf/sha1cd v0.2.3 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
-	github.com/rivo/uniseg v0.4.3 // indirect
+	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/skeema/knownhosts v1.1.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
-	github.com/spf13/cobra v1.4.0 // indirect
+	github.com/spf13/cobra v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.8.1 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/zclconf/go-cty v1.12.1 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/crypto v0.4.0 // indirect
-	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/net v0.4.0 // indirect
-	golang.org/x/sys v0.3.0 // indirect
-	golang.org/x/term v0.3.0 // indirect
-	golang.org/x/text v0.5.0 // indirect
-	golang.org/x/tools v0.1.12 // indirect
-	google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37 // indirect
-	google.golang.org/grpc v1.51.0 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
+	golang.org/x/mod v0.10.0 // indirect
+	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
+	golang.org/x/term v0.8.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
+	golang.org/x/tools v0.6.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
+	google.golang.org/grpc v1.57.0 // indirect
+	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/frand v1.4.2 // indirect
-	sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0 // indirect
+	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600 // indirect
 )

--- a/serverless-gcp-go/go.mod
+++ b/serverless-gcp-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.21
+go 1.20
 
 
 

--- a/serverless-gcp-go/go.mod
+++ b/serverless-gcp-go/go.mod
@@ -1,11 +1,13 @@
 module ${PROJECT}
 
-go 1.20
+go 1.21
+
+toolchain go1.21.3
 
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-alpha.0
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0
 	github.com/pulumi/pulumi-synced-folder/sdk v0.0.9
-	github.com/pulumi/pulumi/sdk/v3 v3.86.0
+	github.com/pulumi/pulumi/sdk/v3 v3.91.1
 )
 
 require (
@@ -13,7 +15,7 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
-	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
@@ -35,9 +37,9 @@ require (
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/hcl/v2 v2.16.1 // indirect
+	github.com/hashicorp/hcl/v2 v2.17.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
-	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
@@ -45,7 +47,7 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
-	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
@@ -55,14 +57,15 @@ require (
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
+	github.com/pulumi/esc v0.5.6 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
-	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/skeema/knownhosts v1.1.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
-	github.com/spf13/cobra v1.6.1 // indirect
+	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
@@ -70,16 +73,17 @@ require (
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	github.com/zclconf/go-cty v1.12.1 // indirect
+	github.com/zclconf/go-cty v1.13.2 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
-	golang.org/x/crypto v0.4.0 // indirect
-	golang.org/x/mod v0.10.0 // indirect
-	golang.org/x/net v0.10.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.8.0 // indirect
-	golang.org/x/term v0.8.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
-	golang.org/x/tools v0.6.0 // indirect
+	golang.org/x/crypto v0.14.0 // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
+	golang.org/x/mod v0.13.0 // indirect
+	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/sync v0.4.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/term v0.13.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
+	golang.org/x/tools v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
 	google.golang.org/grpc v1.57.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect

--- a/serverless-gcp-go/go.mod
+++ b/serverless-gcp-go/go.mod
@@ -2,7 +2,7 @@ module ${PROJECT}
 
 go 1.21
 
-toolchain go1.21.3
+
 
 require (
 	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0

--- a/serverless-gcp-go/go.mod
+++ b/serverless-gcp-go/go.mod
@@ -2,10 +2,8 @@ module ${PROJECT}
 
 go 1.20
 
-
-
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0
 	github.com/pulumi/pulumi-synced-folder/sdk v0.0.9
 	github.com/pulumi/pulumi/sdk/v3 v3.91.1
 )

--- a/serverless-gcp-go/main.go
+++ b/serverless-gcp-go/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/cloudfunctions"
-	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/storage"
+	"github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/cloudfunctions"
+	"github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/storage"
 	synced "github.com/pulumi/pulumi-synced-folder/sdk/go/synced-folder"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"

--- a/serverless-gcp-python/requirements.txt
+++ b/serverless-gcp-python/requirements.txt
@@ -1,3 +1,3 @@
 pulumi>=3.0.0,<4.0.0
-pulumi-gcp==7.0.0a0
+pulumi-gcp==7.0.0rc0
 pulumi-synced-folder>=0.0.0,<1.0.0

--- a/serverless-gcp-python/requirements.txt
+++ b/serverless-gcp-python/requirements.txt
@@ -1,3 +1,3 @@
 pulumi>=3.0.0,<4.0.0
-pulumi-gcp==7.0.0rc0
+pulumi-gcp>=7.0.0,<8.0.0
 pulumi-synced-folder>=0.0.0,<1.0.0

--- a/serverless-gcp-python/requirements.txt
+++ b/serverless-gcp-python/requirements.txt
@@ -1,3 +1,3 @@
 pulumi>=3.0.0,<4.0.0
-pulumi-gcp>=6.0.0,<7.0.0
+pulumi-gcp==7.0.0a0
 pulumi-synced-folder>=0.0.0,<1.0.0

--- a/serverless-gcp-typescript/package.json
+++ b/serverless-gcp-typescript/package.json
@@ -5,7 +5,7 @@
         "@types/node": "^16"
     },
     "dependencies": {
-        "@pulumi/gcp": "7.0.0-rc.0",
+        "@pulumi/gcp": "^7.0.0",
         "@pulumi/pulumi": "^3.49.0",
         "@pulumi/synced-folder": "^0.0.9"
     }

--- a/serverless-gcp-typescript/package.json
+++ b/serverless-gcp-typescript/package.json
@@ -5,7 +5,7 @@
         "@types/node": "^16"
     },
     "dependencies": {
-        "@pulumi/gcp": "7.0.0-alpha.0",
+        "@pulumi/gcp": "7.0.0-rc.0",
         "@pulumi/pulumi": "^3.49.0",
         "@pulumi/synced-folder": "^0.0.9"
     }

--- a/serverless-gcp-typescript/package.json
+++ b/serverless-gcp-typescript/package.json
@@ -5,7 +5,7 @@
         "@types/node": "^16"
     },
     "dependencies": {
-        "@pulumi/gcp": "^6.45.0",
+        "@pulumi/gcp": "7.0.0-alpha.0",
         "@pulumi/pulumi": "^3.49.0",
         "@pulumi/synced-folder": "^0.0.9"
     }

--- a/static-website-gcp-csharp/${PROJECT}.csproj
+++ b/static-website-gcp-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Pulumi" Version="3.*" />
-        <PackageReference Include="Pulumi.Gcp" Version="6.*" />
+        <PackageReference Include="Pulumi.Gcp" Version="7.0.0-alpha.0" />
         <PackageReference Include="Pulumi.SyncedFolder" Version="0.*" />
     </ItemGroup>
 

--- a/static-website-gcp-csharp/${PROJECT}.csproj
+++ b/static-website-gcp-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Pulumi" Version="3.*" />
-        <PackageReference Include="Pulumi.Gcp" Version="7.0.0-alpha.0" />
+        <PackageReference Include="Pulumi.Gcp" Version="7.0.0-rc.0" />
         <PackageReference Include="Pulumi.SyncedFolder" Version="0.*" />
     </ItemGroup>
 

--- a/static-website-gcp-csharp/${PROJECT}.csproj
+++ b/static-website-gcp-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Pulumi" Version="3.*" />
-        <PackageReference Include="Pulumi.Gcp" Version="7.0.0-rc.0" />
+        <PackageReference Include="Pulumi.Gcp" Version="7.*" />
         <PackageReference Include="Pulumi.SyncedFolder" Version="0.*" />
     </ItemGroup>
 

--- a/static-website-gcp-go/go.mod
+++ b/static-website-gcp-go/go.mod
@@ -1,11 +1,13 @@
 module ${PROJECT}
 
-go 1.20
+go 1.21
+
+toolchain go1.21.3
 
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-alpha.0
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0
 	github.com/pulumi/pulumi-synced-folder/sdk v0.0.9
-	github.com/pulumi/pulumi/sdk/v3 v3.86.0
+	github.com/pulumi/pulumi/sdk/v3 v3.91.1
 )
 
 require (
@@ -13,7 +15,7 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
-	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
@@ -35,9 +37,9 @@ require (
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/hcl/v2 v2.16.1 // indirect
+	github.com/hashicorp/hcl/v2 v2.17.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
-	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
@@ -45,7 +47,7 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
-	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
@@ -55,28 +57,30 @@ require (
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
+	github.com/pulumi/esc v0.5.6 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
-	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/skeema/knownhosts v1.1.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
-	github.com/spf13/cobra v1.6.1 // indirect
+	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	github.com/zclconf/go-cty v1.12.1 // indirect
+	github.com/zclconf/go-cty v1.13.2 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a // indirect
-	golang.org/x/net v0.10.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.8.0 // indirect
-	golang.org/x/term v0.8.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
+	golang.org/x/crypto v0.14.0 // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
+	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/sync v0.2.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/term v0.13.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
 	google.golang.org/grpc v1.57.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect

--- a/static-website-gcp-go/go.mod
+++ b/static-website-gcp-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.21
+go 1.20
 
 
 

--- a/static-website-gcp-go/go.mod
+++ b/static-website-gcp-go/go.mod
@@ -3,66 +3,85 @@ module ${PROJECT}
 go 1.20
 
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v6 v6.45.0
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-alpha.0
 	github.com/pulumi/pulumi-synced-folder/sdk v0.0.9
-	github.com/pulumi/pulumi/sdk/v3 v3.49.0
+	github.com/pulumi/pulumi/sdk/v3 v3.86.0
 )
 
 require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
-	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
+	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/cheggaaa/pb v1.0.18 // indirect
-	github.com/djherbis/times v1.2.0 // indirect
-	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/charmbracelet/bubbles v0.16.1 // indirect
+	github.com/charmbracelet/bubbletea v0.24.2 // indirect
+	github.com/charmbracelet/lipgloss v0.7.1 // indirect
+	github.com/cheggaaa/pb v1.0.29 // indirect
+	github.com/cloudflare/circl v1.3.3 // indirect
+	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
+	github.com/djherbis/times v1.5.0 // indirect
+	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
-	github.com/go-git/go-billy/v5 v5.3.1 // indirect
-	github.com/go-git/go-git/v5 v5.4.2 // indirect
-	github.com/gofrs/uuid v3.3.0+incompatible // indirect
+	github.com/go-git/go-billy/v5 v5.4.0 // indirect
+	github.com/go-git/go-git/v5 v5.6.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
-	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/golang/glog v1.1.0 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.0.0 // indirect
-	github.com/imdario/mergo v0.3.12 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/hcl/v2 v2.16.1 // indirect
+	github.com/imdario/mergo v0.3.13 // indirect
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
-	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
-	github.com/mattn/go-runewidth v0.0.8 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/kevinburke/ssh_config v1.2.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.18 // indirect
+	github.com/mattn/go-localereader v0.0.1 // indirect
+	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
-	github.com/opentracing/basictracer-go v1.0.0 // indirect
-	github.com/opentracing/opentracing-go v1.1.0 // indirect
+	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
+	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/muesli/reflow v0.3.0 // indirect
+	github.com/muesli/termenv v0.15.1 // indirect
+	github.com/opentracing/basictracer-go v1.1.0 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
-	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/rogpeppe/go-internal v1.8.1 // indirect
-	github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94 // indirect
+	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
-	github.com/sergi/go-diff v1.1.0 // indirect
-	github.com/spf13/cast v1.3.1 // indirect
-	github.com/spf13/cobra v1.4.0 // indirect
+	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/skeema/knownhosts v1.1.0 // indirect
+	github.com/spf13/cast v1.4.1 // indirect
+	github.com/spf13/cobra v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6 // indirect
+	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
-	github.com/uber/jaeger-client-go v2.22.1+incompatible // indirect
-	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
-	github.com/xanzy/ssh-agent v0.3.2 // indirect
-	go.uber.org/atomic v1.6.0 // indirect
-	golang.org/x/crypto v0.0.0-20220824171710-5757bc0c5503 // indirect
-	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
-	golang.org/x/sys v0.0.0-20220823224334-20c2bfdbfe24 // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
-	golang.org/x/text v0.3.6 // indirect
-	google.golang.org/genproto v0.0.0-20200608115520-7c474a2e3482 // indirect
-	google.golang.org/grpc v1.29.1 // indirect
-	google.golang.org/protobuf v1.24.0 // indirect
+	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
+	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
+	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/zclconf/go-cty v1.12.1 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
+	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a // indirect
+	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
+	golang.org/x/term v0.8.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
+	google.golang.org/grpc v1.57.0 // indirect
+	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/frand v1.4.2 // indirect
-	sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0 // indirect
+	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600 // indirect
 )

--- a/static-website-gcp-go/go.mod
+++ b/static-website-gcp-go/go.mod
@@ -2,7 +2,7 @@ module ${PROJECT}
 
 go 1.21
 
-toolchain go1.21.3
+
 
 require (
 	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0

--- a/static-website-gcp-go/go.mod
+++ b/static-website-gcp-go/go.mod
@@ -2,10 +2,8 @@ module ${PROJECT}
 
 go 1.20
 
-
-
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0
 	github.com/pulumi/pulumi-synced-folder/sdk v0.0.9
 	github.com/pulumi/pulumi/sdk/v3 v3.91.1
 )

--- a/static-website-gcp-go/main.go
+++ b/static-website-gcp-go/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/compute"
-	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/storage"
+	"github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/compute"
+	"github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/storage"
 	synced "github.com/pulumi/pulumi-synced-folder/sdk/go/synced-folder"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"

--- a/static-website-gcp-python/requirements.txt
+++ b/static-website-gcp-python/requirements.txt
@@ -1,3 +1,3 @@
 pulumi>=3.0.0,<4.0.0
-pulumi-gcp==7.0.0a0
+pulumi-gcp==7.0.0rc0
 pulumi-synced-folder>=0.0.0,<1.0.0

--- a/static-website-gcp-python/requirements.txt
+++ b/static-website-gcp-python/requirements.txt
@@ -1,3 +1,3 @@
 pulumi>=3.0.0,<4.0.0
-pulumi-gcp==7.0.0rc0
+pulumi-gcp>=7.0.0,<8.0.0
 pulumi-synced-folder>=0.0.0,<1.0.0

--- a/static-website-gcp-python/requirements.txt
+++ b/static-website-gcp-python/requirements.txt
@@ -1,3 +1,3 @@
 pulumi>=3.0.0,<4.0.0
-pulumi-gcp>=6.0.0,<7.0.0
+pulumi-gcp==7.0.0a0
 pulumi-synced-folder>=0.0.0,<1.0.0

--- a/static-website-gcp-typescript/package.json
+++ b/static-website-gcp-typescript/package.json
@@ -4,7 +4,7 @@
         "@types/node": "^16"
     },
     "dependencies": {
-        "@pulumi/gcp": "7.0.0-alpha.0",
+        "@pulumi/gcp": "7.0.0-rc.0",
         "@pulumi/pulumi": "^3.49.0",
         "@pulumi/synced-folder": "^0.0.9",
         "typescript": "^4.0.0"

--- a/static-website-gcp-typescript/package.json
+++ b/static-website-gcp-typescript/package.json
@@ -4,7 +4,7 @@
         "@types/node": "^16"
     },
     "dependencies": {
-        "@pulumi/gcp": "7.0.0-rc.0",
+        "@pulumi/gcp": "^7.0.0",
         "@pulumi/pulumi": "^3.49.0",
         "@pulumi/synced-folder": "^0.0.9",
         "typescript": "^4.0.0"

--- a/static-website-gcp-typescript/package.json
+++ b/static-website-gcp-typescript/package.json
@@ -4,7 +4,7 @@
         "@types/node": "^16"
     },
     "dependencies": {
-        "@pulumi/gcp": "^6.45.0",
+        "@pulumi/gcp": "7.0.0-alpha.0",
         "@pulumi/pulumi": "^3.49.0",
         "@pulumi/synced-folder": "^0.0.9",
         "typescript": "^4.0.0"

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -696,6 +696,7 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.22 h1:lTqBRUuy8oLhBsnnVZf14uRbIHP
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.22/go.mod h1:YsOa3tFriwWNvBPYHXM5ARiU2yqBNWPWeUiq+4i7Na0=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.8.1/go.mod h1:CM+19rL1+4dFWnOQKwDc7H1KwXTz+h61oUSHyhV0b3o=
 github.com/aws/aws-sdk-go-v2/service/iam v1.19.0 h1:9vCynoqC+dgxZKrsjvAniyIopsv3RZFsZ6wkQ+yxtj8=
+github.com/aws/aws-sdk-go-v2/service/iam v1.19.0/go.mod h1:OyAuvpFeSVNppcSsp1hFOVQcaTRc1LE24YIR7pMbbAA=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.1/go.mod h1:GeUru+8VzrTXV/83XyMJ80KpH8xO89VPoUileyNQ+tc=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.11 h1:y2+VQzC6Zh2ojtV2LoC0MNwHWc6qXv/j2vrQtlftkdA=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.11/go.mod h1:iV4q2hsqtNECrfmlXyord9u4zyuFEJX9eLgLpSPzWA8=
@@ -3398,6 +3399,7 @@ lukechampine.com/frand v1.4.2/go.mod h1:4S/TM2ZgrKejMcKMbeLjISpJMO+/eZ1zu3vYX9dt
 nhooyr.io/websocket v1.8.6/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 pgregory.net/rapid v0.5.5 h1:jkgx1TjbQPD/feRoK+S/mXw9e1uj6WilpHrXJowi6oA=
+pgregory.net/rapid v0.5.5/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=

--- a/vm-gcp-csharp/${PROJECT}.csproj
+++ b/vm-gcp-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.Gcp" Version="7.0.0-rc.0" />
+    <PackageReference Include="Pulumi.Gcp" Version="7.*" />
   </ItemGroup>
 
 </Project>

--- a/vm-gcp-csharp/${PROJECT}.csproj
+++ b/vm-gcp-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.Gcp" Version="7.0.0-alpha.0" />
+    <PackageReference Include="Pulumi.Gcp" Version="7.0.0-rc.0" />
   </ItemGroup>
 
 </Project>

--- a/vm-gcp-csharp/${PROJECT}.csproj
+++ b/vm-gcp-csharp/${PROJECT}.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.Gcp" Version="6.*" />
+    <PackageReference Include="Pulumi.Gcp" Version="7.0.0-alpha.0" />
   </ItemGroup>
 
 </Project>

--- a/vm-gcp-go/go.mod
+++ b/vm-gcp-go/go.mod
@@ -2,10 +2,8 @@ module ${PROJECT}
 
 go 1.20
 
-
-
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0
 	github.com/pulumi/pulumi/sdk/v3 v3.91.1
 )
 

--- a/vm-gcp-go/go.mod
+++ b/vm-gcp-go/go.mod
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.21
+go 1.20
 
 
 

--- a/vm-gcp-go/go.mod
+++ b/vm-gcp-go/go.mod
@@ -3,64 +3,84 @@ module ${PROJECT}
 go 1.20
 
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v6 v6.41.0
-	github.com/pulumi/pulumi/sdk/v3 v3.44.2
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-alpha.0
+	github.com/pulumi/pulumi/sdk/v3 v3.86.0
 )
 
 require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
-	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
+	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/cheggaaa/pb v1.0.18 // indirect
-	github.com/djherbis/times v1.2.0 // indirect
-	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/charmbracelet/bubbles v0.16.1 // indirect
+	github.com/charmbracelet/bubbletea v0.24.2 // indirect
+	github.com/charmbracelet/lipgloss v0.7.1 // indirect
+	github.com/cheggaaa/pb v1.0.29 // indirect
+	github.com/cloudflare/circl v1.3.3 // indirect
+	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
+	github.com/djherbis/times v1.5.0 // indirect
+	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
-	github.com/go-git/go-billy/v5 v5.3.1 // indirect
-	github.com/go-git/go-git/v5 v5.4.2 // indirect
-	github.com/gofrs/uuid v3.3.0+incompatible // indirect
+	github.com/go-git/go-billy/v5 v5.4.0 // indirect
+	github.com/go-git/go-git/v5 v5.6.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
-	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/golang/glog v1.1.0 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.0.0 // indirect
-	github.com/imdario/mergo v0.3.12 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/hcl/v2 v2.16.1 // indirect
+	github.com/imdario/mergo v0.3.13 // indirect
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
-	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
-	github.com/mattn/go-runewidth v0.0.8 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/kevinburke/ssh_config v1.2.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.18 // indirect
+	github.com/mattn/go-localereader v0.0.1 // indirect
+	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
-	github.com/opentracing/basictracer-go v1.0.0 // indirect
-	github.com/opentracing/opentracing-go v1.1.0 // indirect
+	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
+	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/muesli/reflow v0.3.0 // indirect
+	github.com/muesli/termenv v0.15.1 // indirect
+	github.com/opentracing/basictracer-go v1.1.0 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
-	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/rogpeppe/go-internal v1.8.1 // indirect
-	github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94 // indirect
+	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
-	github.com/sergi/go-diff v1.1.0 // indirect
-	github.com/spf13/cast v1.3.1 // indirect
-	github.com/spf13/cobra v1.4.0 // indirect
+	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/skeema/knownhosts v1.1.0 // indirect
+	github.com/spf13/cast v1.4.1 // indirect
+	github.com/spf13/cobra v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6 // indirect
+	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
-	github.com/uber/jaeger-client-go v2.22.1+incompatible // indirect
-	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
-	github.com/xanzy/ssh-agent v0.3.2 // indirect
-	go.uber.org/atomic v1.6.0 // indirect
-	golang.org/x/crypto v0.0.0-20220824171710-5757bc0c5503 // indirect
-	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
-	golang.org/x/sys v0.0.0-20220823224334-20c2bfdbfe24 // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
-	golang.org/x/text v0.3.6 // indirect
-	google.golang.org/genproto v0.0.0-20200608115520-7c474a2e3482 // indirect
-	google.golang.org/grpc v1.29.1 // indirect
-	google.golang.org/protobuf v1.24.0 // indirect
+	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
+	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
+	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/zclconf/go-cty v1.12.1 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
+	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a // indirect
+	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
+	golang.org/x/term v0.8.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
+	google.golang.org/grpc v1.57.0 // indirect
+	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/frand v1.4.2 // indirect
-	sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0 // indirect
+	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600 // indirect
 )

--- a/vm-gcp-go/go.mod
+++ b/vm-gcp-go/go.mod
@@ -2,7 +2,7 @@ module ${PROJECT}
 
 go 1.21
 
-toolchain go1.21.3
+
 
 require (
 	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0

--- a/vm-gcp-go/go.mod
+++ b/vm-gcp-go/go.mod
@@ -1,10 +1,12 @@
 module ${PROJECT}
 
-go 1.20
+go 1.21
+
+toolchain go1.21.3
 
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-alpha.0
-	github.com/pulumi/pulumi/sdk/v3 v3.86.0
+	github.com/pulumi/pulumi-gcp/sdk/v7 v7.0.0-rc.0
+	github.com/pulumi/pulumi/sdk/v3 v3.91.1
 )
 
 require (
@@ -12,7 +14,7 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
-	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
@@ -34,9 +36,9 @@ require (
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/hcl/v2 v2.16.1 // indirect
+	github.com/hashicorp/hcl/v2 v2.17.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
-	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
@@ -44,7 +46,7 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
-	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
@@ -54,28 +56,30 @@ require (
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
+	github.com/pulumi/esc v0.5.6 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
-	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/skeema/knownhosts v1.1.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
-	github.com/spf13/cobra v1.6.1 // indirect
+	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	github.com/zclconf/go-cty v1.12.1 // indirect
+	github.com/zclconf/go-cty v1.13.2 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a // indirect
-	golang.org/x/net v0.10.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.8.0 // indirect
-	golang.org/x/term v0.8.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
+	golang.org/x/crypto v0.14.0 // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
+	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/sync v0.2.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/term v0.13.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
 	google.golang.org/grpc v1.57.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect

--- a/vm-gcp-go/main.go
+++ b/vm-gcp-go/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/compute"
+	"github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/compute"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )

--- a/vm-gcp-python/requirements.txt
+++ b/vm-gcp-python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi-gcp>=6.0.0,<7.0.0
+pulumi-gcp==7.0.0a0

--- a/vm-gcp-python/requirements.txt
+++ b/vm-gcp-python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi-gcp==7.0.0rc0
+pulumi-gcp>=7.0.0,<8.0.0

--- a/vm-gcp-python/requirements.txt
+++ b/vm-gcp-python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
-pulumi-gcp==7.0.0a0
+pulumi-gcp==7.0.0rc0

--- a/vm-gcp-typescript/package.json
+++ b/vm-gcp-typescript/package.json
@@ -6,6 +6,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/gcp": "7.0.0-rc.0"
+        "@pulumi/gcp": "^7.0.0"
     }
 }

--- a/vm-gcp-typescript/package.json
+++ b/vm-gcp-typescript/package.json
@@ -6,6 +6,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/gcp": "^6.0.0"
+        "@pulumi/gcp": "7.0.0-alpha.0"
     }
 }

--- a/vm-gcp-typescript/package.json
+++ b/vm-gcp-typescript/package.json
@@ -6,6 +6,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/gcp": "7.0.0-alpha.0"
+        "@pulumi/gcp": "7.0.0-rc.0"
     }
 }


### PR DESCRIPTION
Update all dependencies to use GCP v7.0.0 🎉 

Fixes https://github.com/pulumi/pulumi-gcp/issues/1250.