### PR TITLE
Add SSH key to enable testing

### DIFF
--- a/vm-azure-csharp/${PROJECT}.csproj
+++ b/vm-azure-csharp/${PROJECT}.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
     <PackageReference Include="Pulumi.Random" Version="4.*" />
+    <PackageReference Include="Pulumi.Tls" Version="4.*" />
   </ItemGroup>
 
 </Project>

--- a/vm-azure-csharp/Pulumi.yaml
+++ b/vm-azure-csharp/Pulumi.yaml
@@ -23,5 +23,3 @@ template:
     servicePort:
       description: The HTTP service port to expose on the VM
       default: "80"
-    sshPublicKey:
-      description: The public key data to use for SSH authentication

--- a/vm-azure-go/Pulumi.yaml
+++ b/vm-azure-go/Pulumi.yaml
@@ -23,5 +23,3 @@ template:
     servicePort:
       description: The HTTP service port to expose on the VM
       default: "80"
-    sshPublicKey:
-      description: The public key data to use for SSH authentication

--- a/vm-azure-go/go.mod
+++ b/vm-azure-go/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/pulumi/pulumi-azure-native-sdk/resources/v2 v2.1.1
 	github.com/pulumi/pulumi-random/sdk/v4 v4.8.2
 	github.com/pulumi/pulumi/sdk/v3 v3.74.0
+	github.com/pulumi/pulumi-tls/sdk/v4 v4.11.1
 )
 
 require (

--- a/vm-azure-go/main.go
+++ b/vm-azure-go/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pulumi/pulumi-azure-native-sdk/network/v2"
 	"github.com/pulumi/pulumi-azure-native-sdk/resources/v2"
 	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
+	tls "github.com/pulumi/pulumi-tls/sdk/v4/go/tls"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
@@ -16,7 +17,7 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 
-		// Import the program's configuration settings.
+		// Import the program's configuration settings
 		cfg := config.New(ctx, "")
 		vmName, err := cfg.Try("vmName")
 		if err != nil {
@@ -38,7 +39,6 @@ func main() {
 		if err != nil {
 			servicePort = "80"
 		}
-		sshPublicKey := cfg.Require("sshPublicKey")
 
 		osImageArgs := strings.Split(osImage, ":")
 		osImagePublisher := osImageArgs[0]
@@ -46,13 +46,22 @@ func main() {
 		osImageSku := osImageArgs[2]
 		osImageVersion := osImageArgs[3]
 
-		// Create a resource group.
+		// Create an SSH key
+		sshKey, err := tls.NewPrivateKey(ctx, "ssh-key", &tls.PrivateKeyArgs{
+			Algorithm: pulumi.String("RSA"),
+			RsaBits:   pulumi.Int(4096),
+		})
+		if err != nil {
+			return err
+		}
+
+		// Create a resource group
 		resourceGroup, err := resources.NewResourceGroup(ctx, "resource-group", nil)
 		if err != nil {
 			return err
 		}
 
-		// Create a virtual network.
+		// Create a virtual network
 		virtualNetwork, err := network.NewVirtualNetwork(ctx, "network", &network.VirtualNetworkArgs{
 			ResourceGroupName: resourceGroup.Name,
 			AddressSpace: network.AddressSpaceArgs{
@@ -71,7 +80,7 @@ func main() {
 			return err
 		}
 
-		// Use a random string to give the VM a unique DNS name.
+		// Use a random string to give the VM a unique DNS name
 		domainLabelSuffix, err := random.NewRandomString(ctx, "domain-label", &random.RandomStringArgs{
 			Length:  pulumi.Int(8),
 			Upper:   pulumi.Bool(false),
@@ -84,7 +93,7 @@ func main() {
 			return fmt.Sprintf("%s-%s", vmName, result)
 		}).(pulumi.StringOutput)
 
-		// Create a public IP address for the VM.
+		// Create a public IP address for the VM
 		publicIp, err := network.NewPublicIPAddress(ctx, "public-ip", &network.PublicIPAddressArgs{
 			ResourceGroupName:        resourceGroup.Name,
 			PublicIPAllocationMethod: pulumi.StringPtr("Dynamic"),
@@ -96,7 +105,7 @@ func main() {
 			return err
 		}
 
-		// Create a security group allowing inbound access over ports 80 (for HTTP) and 22 (for SSH).
+		// Create a security group allowing inbound access over ports 80 (for HTTP) and 22 (for SSH)
 		securityGroup, err := network.NewNetworkSecurityGroup(ctx, "security-group", &network.NetworkSecurityGroupArgs{
 			ResourceGroupName: resourceGroup.Name,
 			SecurityRules: network.SecurityRuleTypeArray{
@@ -120,7 +129,7 @@ func main() {
 			return err
 		}
 
-		// Create a network interface with the virtual network, IP address, and security group.
+		// Create a network interface with the virtual network, IP address, and security group
 		networkInterface, err := network.NewNetworkInterface(ctx, "network-interface", &network.NetworkInterfaceArgs{
 			ResourceGroupName: resourceGroup.Name,
 			NetworkSecurityGroup: &network.NetworkSecurityGroupTypeArgs{
@@ -145,7 +154,7 @@ func main() {
 			return err
 		}
 
-		// Define a script to be run when the VM starts up.
+		// Define a script to be run when the VM starts up
 		initScript := fmt.Sprintf(`#!/bin/bash
 			echo '<!DOCTYPE html>
 			<html lang="en">
@@ -160,7 +169,7 @@ func main() {
 			</html>' > index.html
 			sudo python3 -m http.server %s &`, servicePort)
 
-		// Create the virtual machine.
+		// Create the virtual machine
 		vm, err := compute.NewVirtualMachine(ctx, "vm", &compute.VirtualMachineArgs{
 			ResourceGroupName: resourceGroup.Name,
 			NetworkProfile: &compute.NetworkProfileArgs{
@@ -183,7 +192,7 @@ func main() {
 					Ssh: &compute.SshConfigurationArgs{
 						PublicKeys: compute.SshPublicKeyTypeArray{
 							&compute.SshPublicKeyTypeArgs{
-								KeyData: pulumi.String(sshPublicKey),
+								KeyData: sshKey.PublicKeyOpenssh,
 								Path:    pulumi.String(fmt.Sprintf("/home/%v/.ssh/authorized_keys", adminUsername)),
 							},
 						},
@@ -207,7 +216,7 @@ func main() {
 			return err
 		}
 
-		// Once the machine is created, fetch its IP address and DNS hostname.
+		// Once the machine is created, fetch its IP address and DNS hostname
 		address := vm.ID().ApplyT(func(_ pulumi.ID) network.LookupPublicIPAddressResultOutput {
 			return network.LookupPublicIPAddressOutput(ctx, network.LookupPublicIPAddressOutputArgs{
 				ResourceGroupName:   resourceGroup.Name,
@@ -215,7 +224,7 @@ func main() {
 			})
 		})
 
-		// Export the VM's hostname, public IP address, and HTTP URL.
+		// Export the VM's hostname, public IP address, HTTP URL, and SSH private key
 		ctx.Export("ip", address.ApplyT(func(addr network.LookupPublicIPAddressResult) (string, error) {
 			return *addr.IpAddress, nil
 		}).(pulumi.StringOutput))
@@ -227,6 +236,8 @@ func main() {
 		ctx.Export("url", address.ApplyT(func(addr network.LookupPublicIPAddressResult) (string, error) {
 			return fmt.Sprintf("http://%s:%s", *addr.DnsSettings.Fqdn, servicePort), nil
 		}).(pulumi.StringOutput))
+
+		ctx.Export("privatekey", sshKey.PrivateKeyOpenssh)
 
 		return nil
 	})

--- a/vm-azure-python/Pulumi.yaml
+++ b/vm-azure-python/Pulumi.yaml
@@ -23,5 +23,3 @@ template:
     servicePort:
       description: The HTTP service port to expose on the VM
       default: "80"
-    sshPublicKey:
-      description: The public key data to use for SSH authentication

--- a/vm-azure-python/requirements.txt
+++ b/vm-azure-python/requirements.txt
@@ -1,3 +1,4 @@
 pulumi>=3.0.0,<4.0.0
 pulumi-azure-native>=2.0.0,<3.0.0
 pulumi-random>=4.0.0,<5.0.0
+pulumi-tls>=4.0.0,<5.0.0

--- a/vm-azure-typescript/Pulumi.yaml
+++ b/vm-azure-typescript/Pulumi.yaml
@@ -23,5 +23,3 @@ template:
     servicePort:
       description: The HTTP service port to expose on the VM
       default: "80"
-    sshPublicKey:
-      description: The public key data to use for SSH authentication

--- a/vm-azure-typescript/index.ts
+++ b/vm-azure-typescript/index.ts
@@ -3,22 +3,28 @@ import * as resources from "@pulumi/azure-native/resources";
 import * as network from "@pulumi/azure-native/network";
 import * as compute from "@pulumi/azure-native/compute";
 import * as random from "@pulumi/random";
+import * as tls from "@pulumi/tls";
 
-// Import the program's configuration settings.
+// Import the program's configuration settings
 const config = new pulumi.Config();
 const vmName = config.get("vmName") || "my-server";
 const vmSize = config.get("vmSize") || "Standard_A1_v2";
 const osImage = config.get("osImage") || "Debian:debian-11:11:latest";
 const adminUsername = config.get("adminUsername") || "pulumiuser";
 const servicePort = config.get("servicePort") || "80";
-const sshPublicKey = config.require("sshPublicKey");
 
 const [ osImagePublisher, osImageOffer, osImageSku, osImageVersion ] = osImage.split(":");
 
-// Create a resource group.
+// Create an SSH key
+const sshKey = new tls.PrivateKey("ssh-key", {
+    algorithm: "RSA",
+    rsaBits: 4096,
+});
+
+// Create a resource group
 const resourceGroup = new resources.ResourceGroup("resource-group");
 
-// Create a virtual network.
+// Create a virtual network
 const virtualNetwork = new network.VirtualNetwork("network", {
     resourceGroupName: resourceGroup.name,
     addressSpace: {
@@ -32,14 +38,14 @@ const virtualNetwork = new network.VirtualNetwork("network", {
     ],
 });
 
-// Use a random string to give the VM a unique DNS name.
+// Use a random string to give the VM a unique DNS name
 var domainNameLabel = new random.RandomString("domain-label", {
     length: 8,
     upper: false,
     special: false,
 }).result.apply(result => `${vmName}-${result}`);
 
-// Create a public IP address for the VM.
+// Create a public IP address for the VM
 const publicIp = new network.PublicIPAddress("public-ip", {
     resourceGroupName: resourceGroup.name,
     publicIPAllocationMethod: network.IPAllocationMethod.Dynamic,
@@ -48,7 +54,7 @@ const publicIp = new network.PublicIPAddress("public-ip", {
     },
 });
 
-// Create a security group allowing inbound access over ports 80 (for HTTP) and 22 (for SSH).
+// Create a security group allowing inbound access over ports 80 (for HTTP) and 22 (for SSH)
 const securityGroup = new network.NetworkSecurityGroup("security-group", {
     resourceGroupName: resourceGroup.name,
     securityRules: [
@@ -69,7 +75,7 @@ const securityGroup = new network.NetworkSecurityGroup("security-group", {
     ]
 });
 
-// Create a network interface with the virtual network, IP address, and security group.
+// Create a network interface with the virtual network, IP address, and security group
 const networkInterface = new network.NetworkInterface("network-interface", {
     resourceGroupName: resourceGroup.name,
     networkSecurityGroup: {
@@ -87,7 +93,7 @@ const networkInterface = new network.NetworkInterface("network-interface", {
     }],
 });
 
-// Define a script to be run when the VM starts up.
+// Define a script to be run when the VM starts up
 const initScript = `#!/bin/bash
     echo '<!DOCTYPE html>
     <html lang="en">
@@ -102,7 +108,7 @@ const initScript = `#!/bin/bash
     </html>' > index.html
     sudo python3 -m http.server ${servicePort} &`;
 
-// Create the virtual machine.
+// Create the virtual machine
 const vm = new compute.VirtualMachine("vm", {
     resourceGroupName: resourceGroup.name,
     networkProfile: {
@@ -125,7 +131,7 @@ const vm = new compute.VirtualMachine("vm", {
             ssh: {
                 publicKeys: [
                     {
-                        keyData: sshPublicKey,
+                        keyData: sshKey.publicKeyOpenssh,
                         path: `/home/${adminUsername}/.ssh/authorized_keys`,
                     },
                 ],
@@ -146,13 +152,14 @@ const vm = new compute.VirtualMachine("vm", {
     },
 });
 
-// Once the machine is created, fetch its IP address and DNS hostname.
+// Once the machine is created, fetch its IP address and DNS hostname
 const vmAddress = vm.id.apply(_ => network.getPublicIPAddressOutput({
     resourceGroupName: resourceGroup.name,
     publicIpAddressName: publicIp.name,
 }));
 
-// Export the VM's hostname, public IP address, and HTTP URL.
+// Export the VM's hostname, public IP address, HTTP URL, and SSH private key
 export const ip = vmAddress.ipAddress;
 export const hostname = vmAddress.dnsSettings?.apply(settings => settings?.fqdn);
 export const url = hostname?.apply(name => `http://${name}:${servicePort}`);
+export const privatekey = sshKey.privateKeyOpenssh;

--- a/vm-azure-typescript/package.json
+++ b/vm-azure-typescript/package.json
@@ -7,6 +7,7 @@
     "dependencies": {
         "@pulumi/azure-native": "^2.0.0",
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/random": "^4.8.2"
+        "@pulumi/random": "^4.8.2",
+        "@pulumi/tls": "^4.0.0"
     }
 }

--- a/vm-azure-yaml/Pulumi.yaml
+++ b/vm-azure-yaml/Pulumi.yaml
@@ -23,10 +23,8 @@ template:
     servicePort:
       description: The HTTP service port to expose on the VM
       default: "80"
-    sshPublicKey:
-      description: The public key data to use for SSH authentication
 
-# Import the program's configuration settings.
+# Import the program's configuration settings
 config:
   adminUsername:
     type: string
@@ -43,13 +41,11 @@ config:
   servicePort:
     type: string
     default: "80"
-  sshPublicKey:
-    type: string
 
 variables:
   dnsName: ${vmName}-${random-string.result}
 
-  # Define a script to be run when the VM starts up.
+  # Define a script to be run when the VM starts up
   initScript:
     fn::toBase64: |
       #!/bin/bash
@@ -74,7 +70,7 @@ variables:
   osImageSku: ${osImageArgs[2]}
   osImageVersion: ${osImageArgs[3]}
 
-  # Once the machine is created, fetch its IP address and DNS hostname.
+  # Once the machine is created, fetch its IP address and DNS hostname
   address:
     fn::invoke:
       function: azure-native:network:getPublicIPAddress
@@ -85,11 +81,18 @@ variables:
 
 resources:
 
-  # Create a resource group.
+  # Create an SSH key
+  ssh-key:
+    properties:
+      algorithm: RSA
+      rsaBits: 4096
+    type: tls:PrivateKey
+
+  # Create a resource group
   resource-group:
     type: azure-native:resources:ResourceGroup
 
-  # Create a virtual network.
+  # Create a virtual network
   network:
     type: azure-native:network:VirtualNetwork
     properties:
@@ -101,7 +104,7 @@ resources:
         - name: default
           addressPrefix: 10.0.1.0/24
 
-  # Use a random string to give the VM a unique DNS name.
+  # Use a random string to give the VM a unique DNS name
   random-string:
     type: random:RandomString
     properties:
@@ -109,7 +112,7 @@ resources:
       upper: false
       special: false
 
-  # Create a public IP address for the VM.
+  # Create a public IP address for the VM
   public-ip:
     type: azure-native:network:PublicIPAddress
     properties:
@@ -118,7 +121,7 @@ resources:
       dnsSettings:
         domainNameLabel: ${dnsName}
 
-  # Create a security group allowing inbound access over ports 80 (for HTTP) and 22 (for SSH).
+  # Create a security group allowing inbound access over ports 80 (for HTTP) and 22 (for SSH)
   security-group:
     type: azure-native:network:NetworkSecurityGroup
     properties:
@@ -133,10 +136,10 @@ resources:
           sourceAddressPrefix: "*"
           destinationAddressPrefix: "*"
           destinationPortRanges:
-            - ${servicePort}
+            - fn::toJSON: ${servicePort}
             - "22"
 
-  # Create a network interface with the virtual network, IP address, and security group.
+  # Create a network interface with the virtual network, IP address, and security group
   network-interface:
     type: azure-native:network:NetworkInterface
     properties:
@@ -151,7 +154,7 @@ resources:
           publicIPAddress:
             id: ${public-ip.id}
 
-  # Create the virtual machine.
+  # Create the virtual machine
   vm:
     type: azure-native:compute:VirtualMachine
     properties:
@@ -170,7 +173,7 @@ resources:
           disablePasswordAuthentication: true
           ssh:
             publicKeys:
-              - keyData: ${sshPublicKey}
+              - keyData: ${ssh-key.publicKeyOpenssh}
                 path: /home/${adminUsername}/.ssh/authorized_keys
       storageProfile:
         osDisk:
@@ -182,8 +185,9 @@ resources:
           sku: ${osImageSku}
           version: ${osImageVersion}
 
-# Export the VM's hostname, public IP address, and HTTP URL.
+# Export the VM's hostname, public IP address, HTTP URL, and SSH private key
 outputs:
   ip: ${address.ipAddress}
   hostname: ${address.dnsSettings.fqdn}
   url: http://${address.dnsSettings.fqdn}:${servicePort}
+  privatekey: ${ssh-key.privateKeyOpenssh}


### PR DESCRIPTION
This PR adds an SSH key to the "VM on Azure" architecture templates. Adding the SSH key enables automated testing of the templates, which are currently excluded from automated testing.

The PR includes the following changes:
* Updates templates to add an SSH key resource
* Uses the SSH key resource for the VM resource
* Removes the SSH key as a required configuration value