### PR TITLE
Update to dotnet 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         go-version: [1.21.x]
         node-version: [18.x]
         python-version: [3.7]
-        dotnet: [6.0.x]
+        dotnet: [8.0.x]
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: read

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -35,7 +35,7 @@ jobs:
         go-version: [1.21.x]
         node-version: [18.x]
         python-version: [3.7]
-        dotnet: [6.0.x]
+        dotnet: [8.0.x]
         pulumi-version:
           - latest
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -35,7 +35,7 @@ jobs:
         go-version: [1.21.x]
         node-version: [18.x]
         python-version: [3.7]
-        dotnet: [6.0.x]
+        dotnet: [8.0.x]
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: read

--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -46,7 +46,7 @@ jobs:
         go-version: [1.21.x]
         node-version: [18.x]
         python-version: [3.7]
-        dotnet: [6.0.x]
+        dotnet: [8.0.x]
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: read

--- a/alicloud-csharp/${PROJECT}.csproj
+++ b/alicloud-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/alicloud-fsharp/${PROJECT}.fsproj
+++ b/alicloud-fsharp/${PROJECT}.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/alicloud-visualbasic/${PROJECT}.vbproj
+++ b/alicloud-visualbasic/${PROJECT}.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace></RootNamespace>
   </PropertyGroup>

--- a/auth0-csharp/${PROJECT}.csproj
+++ b/auth0-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/aws-csharp/${PROJECT}.csproj
+++ b/aws-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/aws-fsharp/${PROJECT}.fsproj
+++ b/aws-fsharp/${PROJECT}.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/aws-native-csharp/${PROJECT}.csproj
+++ b/aws-native-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/aws-native-fsharp/${PROJECT}.fsproj
+++ b/aws-native-fsharp/${PROJECT}.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/aws-native-visualbasic/${PROJECT}.vbproj
+++ b/aws-native-visualbasic/${PROJECT}.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace></RootNamespace>
   </PropertyGroup>

--- a/aws-visualbasic/${PROJECT}.vbproj
+++ b/aws-visualbasic/${PROJECT}.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace></RootNamespace>
   </PropertyGroup>

--- a/azure-classic-csharp/${PROJECT}.csproj
+++ b/azure-classic-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-classic-fsharp/${PROJECT}.fsproj
+++ b/azure-classic-fsharp/${PROJECT}.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-classic-visualbasic/${PROJECT}.vbproj
+++ b/azure-classic-visualbasic/${PROJECT}.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace></RootNamespace>
   </PropertyGroup>

--- a/azure-csharp/${PROJECT}.csproj
+++ b/azure-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-fsharp/${PROJECT}.fsproj
+++ b/azure-fsharp/${PROJECT}.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/container-aws-csharp/${PROJECT}.csproj
+++ b/container-aws-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/container-azure-csharp/${PROJECT}.csproj
+++ b/container-azure-csharp/${PROJECT}.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <!-- Ignore the files in the app folder. -->

--- a/container-azure-csharp/app/App.csproj
+++ b/container-azure-csharp/app/App.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <RootNamespace></RootNamespace>

--- a/container-gcp-csharp/${PROJECT}.csproj
+++ b/container-gcp-csharp/${PROJECT}.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <!-- Ignore the files in the app folder. -->

--- a/container-gcp-csharp/app/App.csproj
+++ b/container-gcp-csharp/app/App.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <RootNamespace></RootNamespace>

--- a/csharp/${PROJECT}.csproj
+++ b/csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/fsharp/${PROJECT}.fsproj
+++ b/fsharp/${PROJECT}.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/gcp-csharp/${PROJECT}.csproj
+++ b/gcp-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/gcp-fsharp/${PROJECT}.fsproj
+++ b/gcp-fsharp/${PROJECT}.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/gcp-visualbasic/${PROJECT}.vbproj
+++ b/gcp-visualbasic/${PROJECT}.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace></RootNamespace>
   </PropertyGroup>

--- a/github-csharp/${PROJECT}.csproj
+++ b/github-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/google-native-csharp/${PROJECT}.csproj
+++ b/google-native-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/helm-kubernetes-csharp/${PROJECT}.csproj
+++ b/helm-kubernetes-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/kubernetes-aws-csharp/${PROJECT}.csproj
+++ b/kubernetes-aws-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/kubernetes-azure-csharp/${PROJECT}.csproj
+++ b/kubernetes-azure-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/kubernetes-csharp/${PROJECT}.csproj
+++ b/kubernetes-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/kubernetes-fsharp/${PROJECT}.fsproj
+++ b/kubernetes-fsharp/${PROJECT}.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/kubernetes-gcp-csharp/${PROJECT}.csproj
+++ b/kubernetes-gcp-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/random-csharp/${PROJECT}.csproj
+++ b/random-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/serverless-aws-csharp/${PROJECT}.csproj
+++ b/serverless-aws-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/serverless-azure-csharp/${PROJECT}.csproj
+++ b/serverless-azure-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 
         <!-- Ignore the files in the api folder. -->

--- a/serverless-azure-csharp/app/App.csproj
+++ b/serverless-azure-csharp/app/App.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/serverless-gcp-csharp/${PROJECT}.csproj
+++ b/serverless-gcp-csharp/${PROJECT}.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <!-- Ignore the files in the api folder. -->

--- a/serverless-gcp-csharp/app/App.csproj
+++ b/serverless-gcp-csharp/app/App.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0" />

--- a/static-website-aws-csharp/${PROJECT}.csproj
+++ b/static-website-aws-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/static-website-azure-csharp/${PROJECT}.csproj
+++ b/static-website-azure-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/static-website-gcp-csharp/${PROJECT}.csproj
+++ b/static-website-gcp-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/visualbasic/${PROJECT}.vbproj
+++ b/visualbasic/${PROJECT}.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace></RootNamespace>
   </PropertyGroup>

--- a/vm-aws-csharp/${PROJECT}.csproj
+++ b/vm-aws-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/vm-azure-csharp/${PROJECT}.csproj
+++ b/vm-azure-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/vm-gcp-csharp/${PROJECT}.csproj
+++ b/vm-gcp-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/webapp-kubernetes-csharp/${PROJECT}.csproj
+++ b/webapp-kubernetes-csharp/${PROJECT}.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 


### PR DESCRIPTION
.NET 8 is an LTS release. We should update templates to use this rather than 6.

N.B. We didn't update templates for 7 because it wasn't an LTS release.