### PR TITLE
Update GCP cloudrun template to use docker image repo digest identifier

### DIFF
--- a/container-gcp-csharp/Program.cs
+++ b/container-gcp-csharp/Program.cs
@@ -70,7 +70,7 @@ return await Deployment.RunAsync(() =>
                 {
                     new Gcp.CloudRun.Inputs.ServiceTemplateSpecContainerArgs
                     {
-                        Image = image.ImageName,
+                        Image = image.RepoDigest,
                         Resources = new Gcp.CloudRun.Inputs.ServiceTemplateSpecContainerResourcesArgs
                         {
                             Limits = {

--- a/container-gcp-go/main.go
+++ b/container-gcp-go/main.go
@@ -97,7 +97,7 @@ func main() {
 				Spec: cloudrun.ServiceTemplateSpecArgs{
 					Containers: cloudrun.ServiceTemplateSpecContainerArray{
 						cloudrun.ServiceTemplateSpecContainerArgs{
-							Image: image.RepoDigest,
+							Image: image.RepoDigest.Elem(),
 							Resources: cloudrun.ServiceTemplateSpecContainerResourcesArgs{
 								Limits: pulumi.ToStringMap(map[string]string{
 									"memory": memory,

--- a/container-gcp-go/main.go
+++ b/container-gcp-go/main.go
@@ -97,7 +97,7 @@ func main() {
 				Spec: cloudrun.ServiceTemplateSpecArgs{
 					Containers: cloudrun.ServiceTemplateSpecContainerArray{
 						cloudrun.ServiceTemplateSpecContainerArgs{
-							Image: image.ImageName,
+							Image: image.RepoDigest,
 							Resources: cloudrun.ServiceTemplateSpecContainerResourcesArgs{
 								Limits: pulumi.ToStringMap(map[string]string{
 									"memory": memory,

--- a/container-gcp-python/__main__.py
+++ b/container-gcp-python/__main__.py
@@ -73,7 +73,7 @@ service = cloudrun.Service(
             spec=cloudrun.ServiceTemplateSpecArgs(
                 containers=[
                     cloudrun.ServiceTemplateSpecContainerArgs(
-                        image=image.image_name,
+                        image=image.repo_digest,
                         resources=cloudrun.ServiceTemplateSpecContainerResourcesArgs(
                             limits=dict(
                                 memory=memory,

--- a/container-gcp-typescript/index.ts
+++ b/container-gcp-typescript/index.ts
@@ -61,7 +61,7 @@ const service = new gcp.cloudrun.Service("service", {
         spec: {
             containers: [
                 {
-                    image: image.imageName,
+                    image: image.repoDigest,
                     resources: {
                         limits: {
                             memory,


### PR DESCRIPTION
Update GCP cloudrun template to use docker image repo digest identifier

By using image name in the cloud run service, the image won't be redeployed when the app changes currently.

Ref:
https://github.com/pulumi/pulumi-gcp/issues/1166
https://github.com/pulumi/pulumi-docker/issues/726
https://github.com/pulumi/pulumi-docker/pull/739