### PR TITLE
[ci] force update of pulumi cli to > 3.95.0

### DIFF
--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -19,6 +19,7 @@ env:
   LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
   SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,vm-azure-yaml"
   PULUMI_API: https://api.pulumi-staging.io
+  PULUMI_VERSION: "^3.95.0"
   ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}

--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -19,7 +19,7 @@ env:
   LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
   SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,vm-azure-yaml"
   PULUMI_API: https://api.pulumi-staging.io
-  PULUMI_VERSION: "^3.95.0"
+  PULUMI_VERSION: "3.95.0"
   ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}

--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -19,7 +19,7 @@ env:
   LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
   SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,vm-azure-yaml"
   PULUMI_API: https://api.pulumi-staging.io
-  PULUMI_VERSION: "3.95.0"
+  MIN_PULUMI_VERSION: "3.95.0"
   ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
@@ -78,7 +78,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/actions@v4
         with:
-          pulumi-version: ${{ env.PULUMI_VERSION != '' && format('v{0}', env.PULUMI_VERSION) || null }}
+          pulumi-version: ${{ env.MIN_PULUMI_VERSION != '' && format('^v{0}', env.MIN_PULUMI_VERSION) || null }}
       - run: pulumi version
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4


### PR DESCRIPTION
Force an update of the Pulumi CLI to a min version of 3.95 as it adds support for new fields that have been added to templates.

The tests failing on this PR are related to our azure storage changing. I'm following up with that in a separate PR.

My [last PR](https://github.com/pulumi/templates/pull/697/) merged unexpectedly even with tests failing :/