### PR TITLE
[ci] enforce min CLI version of 3.95.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ env:
   SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,vm-azure"
   PULUMI_API: https://api.pulumi-staging.io
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  PULUMI_VERSION: ${{ github.event.client_payload.ref }}
+  MIN_PULUMI_VERSION: ${{ github.event.client_payload.ref != "" && github.event.client_payload.ref || "3.95.0"}}
   ARM_CLIENT_ID:  ${{ secrets.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
   ARM_SUBSCRIPTION_ID:  ${{ secrets.ARM_SUBSCRIPTION_ID }}
@@ -71,7 +71,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/actions@v4
         with:
-          pulumi-version: ${{ env.PULUMI_VERSION != '' && format('v{0}', env.PULUMI_VERSION) || null }}
+          pulumi-version: ${{ env.MIN_PULUMI_VERSION != '' && format('^v{0}', env.MIN_PULUMI_VERSION) || null }}
       - run: pulumi version
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4


### PR DESCRIPTION
mirrors https://github.com/pulumi/templates/pull/700 but for the release actions that are run only on merge
