### PR TITLE
Fix spacing in C# programs

### DIFF
--- a/aws-csharp/Program.cs
+++ b/aws-csharp/Program.cs
@@ -4,12 +4,12 @@ using System.Collections.Generic;
 
 return await Deployment.RunAsync(() =>
 {
-   // Create an AWS resource (S3 Bucket)
-   var bucket = new Bucket("my-bucket");
+    // Create an AWS resource (S3 Bucket)
+    var bucket = new Bucket("my-bucket");
 
-   // Export the name of the bucket
-   return new Dictionary<string, object?>
-   {
-      ["bucketName"] = bucket.Id
-   };
+    // Export the name of the bucket
+    return new Dictionary<string, object?>
+    {
+        ["bucketName"] = bucket.Id
+    };
 });

--- a/csharp/Program.cs
+++ b/csharp/Program.cs
@@ -3,12 +3,12 @@ using Pulumi;
 
 return await Deployment.RunAsync(() =>
 {
-   // Add your resources here
-   // e.g. var resource = new Resource("name", new ResourceArgs { });
+    // Add your resources here
+    // e.g. var resource = new Resource("name", new ResourceArgs { });
 
-   // Export outputs here
-   return new Dictionary<string, object?>
-   {
-      ["outputKey"] = "outputValue"
-   };
+    // Export outputs here
+    return new Dictionary<string, object?>
+    {
+        ["outputKey"] = "outputValue"
+    };
 });


### PR DESCRIPTION
Fix two C# templates that were using three spaces instead of four. Verified all other C# templates are using four spaces.

Fixes #703.