### PR TITLE
Set Node versions to 18

### DIFF
--- a/aiven-typescript/package.json
+++ b/aiven-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.20.0",

--- a/alicloud-typescript/package.json
+++ b/alicloud-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/auth0-typescript/package.json
+++ b/auth0-typescript/package.json
@@ -2,7 +2,7 @@
   "name": "${PROJECT}",
   "main": "index.ts",
   "devDependencies": {
-    "@types/node": "^16"
+    "@types/node": "^18"
   },
   "dependencies": {
     "@pulumi/pulumi": "^3.20.0",

--- a/aws-native-typescript/package.json
+++ b/aws-native-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/azure-classic-typescript/package.json
+++ b/azure-classic-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/azure-typescript/package.json
+++ b/azure-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/container-aws-typescript/package.json
+++ b/container-aws-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-	    "@types/node": "^16"
+	    "@types/node": "^18"
     },
     "dependencies": {
 	    "typescript": "^4.0.0",

--- a/container-azure-typescript/package.json
+++ b/container-azure-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/azure-native": "^2.0.0",

--- a/container-gcp-typescript/package.json
+++ b/container-gcp-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/docker": "^4.2.3",

--- a/digitalocean-typescript/package.json
+++ b/digitalocean-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/equinix-metal-typescript/package.json
+++ b/equinix-metal-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/gcp-typescript/package.json
+++ b/gcp-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/github-typescript/package.json
+++ b/github-typescript/package.json
@@ -2,7 +2,7 @@
   "name": "${PROJECT}",
   "main": "index.ts",
   "devDependencies": {
-    "@types/node": "^16"
+    "@types/node": "^18"
   },
   "dependencies": {
     "@pulumi/pulumi": "^3.19.0",

--- a/google-native-typescript/package.json
+++ b/google-native-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.1.0",

--- a/helm-kubernetes-typescript/package.json
+++ b/helm-kubernetes-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "test",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "typescript": "^4.0.0",

--- a/kubernetes-azure-typescript/package.json
+++ b/kubernetes-azure-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/kubernetes-gcp-typescript/package.json
+++ b/kubernetes-gcp-typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "${PROJECT}",
   "devDependencies": {
-    "@types/node": "^16"
+    "@types/node": "^18"
   },
   "dependencies": {
     "typescript": "^4.0.0",

--- a/kubernetes-typescript/package.json
+++ b/kubernetes-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/openstack-typescript/package.json
+++ b/openstack-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/random-typescript/package.json
+++ b/random-typescript/package.json
@@ -2,7 +2,7 @@
   "name": "${PROJECT}",
   "main": "index.ts",
   "devDependencies": {
-    "@types/node": "^16"
+    "@types/node": "^18"
   },
   "dependencies": {
     "@pulumi/pulumi": "^3.19.0",

--- a/serverless-azure-typescript/package.json
+++ b/serverless-azure-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
     "@pulumi/azure-native": "^2.0.0",

--- a/serverless-gcp-typescript/package.json
+++ b/serverless-gcp-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/gcp": "^7.0.0",

--- a/static-website-aws-typescript/package.json
+++ b/static-website-aws-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/aws": "^6.0.2",

--- a/static-website-azure-typescript/package.json
+++ b/static-website-azure-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/azure-native": "^2.0.0",

--- a/static-website-gcp-typescript/package.json
+++ b/static-website-gcp-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/gcp": "^7.0.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0"

--- a/vm-aws-typescript/package.json
+++ b/vm-aws-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "typescript": "^4.0.0",

--- a/vm-azure-typescript/package.json
+++ b/vm-azure-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "vm-azure-typescript",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/azure-native": "^2.0.0",

--- a/vm-gcp-typescript/package.json
+++ b/vm-gcp-typescript/package.json
@@ -2,7 +2,7 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/webapp-kubernetes-typescript/package.json
+++ b/webapp-kubernetes-typescript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "webapp-kubernetes-typescript",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^18"
     },
     "dependencies": {
         "typescript": "^4.0.0",


### PR DESCRIPTION
This is the [version we currently support](https://www.pulumi.com/docs/languages-sdks/javascript/), so this change updates all templates' `@types/node` versions accordingly.