### PR TITLE
always use the latest pulumi dev version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,9 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - run: go env
       - name: Install Pulumi CLI
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@v5
         with:
-          pulumi-version: ${{ env.PULUMI_VERSION != '' && format('v{0}', env.PULUMI_VERSION) || null }}
+          pulumi-version: ${{ env.PULUMI_VERSION != '' && format('v{0}', env.PULUMI_VERSION) || dev }}
       - run: pulumi version
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -64,19 +64,10 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
-      - if: matrix.pulumi-version == 'latest'
-        name: Install Latest Pulumi CLI
-        uses: pulumi/actions@v4
-      - if: matrix.pulumi-version == 'dev'
-        name: Get Latest Dev Version of Pulumi
-        shell: bash
-        run: |
-          echo "DEV_PULUMI_VERSION=$(curl -sSL "http://registry.npmjs.org/-/package/@pulumi/pulumi/dist-tags" | jq -r .dev)" >> $GITHUB_ENV
-      - if: matrix.pulumi-version == 'dev'
-        name: Install Latest Pulumi CLI
-        uses: pulumi/actions@v4
+      - name: Install Latest Pulumi CLI
+        uses: pulumi/actions@v5
         with:
-          pulumi-version: ${{ env.DEV_PULUMI_VERSION }}
+          pulumi-version: ${{ matrix.pulumi-version }}
       - run: echo "Currently Pulumi $(pulumi version) is installed"
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -96,12 +96,10 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0
         with:
           install_components: gke-gcloud-auth-plugin
-      # TODO find a way to preferably use latest dev builds here instead:
-      # https://github.com/pulumi/pulumi/issues/10728
       - name: Install Latest Pulumi CLI
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@v5
         with:
-          pulumi-version: latest
+          pulumi-version: dev
       - run: echo "Currently Pulumi $(pulumi version) is installed"
       - name: Install Testing Dependencies
         run: make ensure

--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -19,7 +19,6 @@ env:
   LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
   SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,civo,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,vm-azure-yaml"
   PULUMI_API: https://api.pulumi-staging.io
-  MIN_PULUMI_VERSION: "3.95.0"
   ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
@@ -76,9 +75,9 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - run: go env
       - name: Install Pulumi CLI
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@v5
         with:
-          pulumi-version: ${{ env.MIN_PULUMI_VERSION != '' && format('^v{0}', env.MIN_PULUMI_VERSION) || null }}
+          pulumi-version: dev
       - run: pulumi version
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4


### PR DESCRIPTION
Similar to https://github.com/pulumi/examples/pull/1535, we would like to use the latest pulumi dev version here instead of just the latest version.

In fact in some places there was some (very outdated and no longer functional) code to attempt that.  Instead of the latest dev version it downloaded 3.40.0-alpha.1663101047 as of the time of this writing, which is less than ideal.  Always use the dev version here unless we explicitly request the "latest" version.

Fixes https://github.com/pulumi/pulumi/issues/10728