### PR TITLE
Bumping up the version of synced-folder to fix the issue with using AWS SSO-based credentials

### DIFF
--- a/static-website-aws-typescript/package.json
+++ b/static-website-aws-typescript/package.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "@pulumi/aws": "^6.0.2",
         "@pulumi/pulumi": "^3.49.0",
-        "@pulumi/synced-folder": "^0.0.9",
+        "@pulumi/synced-folder": "^0.11.1",
         "typescript": "^4.0.0"
     }
 }


### PR DESCRIPTION
The template didn't work for the case when AWS CLI credentials are managed using `aws configure sso` and `aws sso login` which look like a preferred way nowadays to avoid storing long-term credentials locally (e.g. see [here](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-prereqs.html)).