### PR TITLE
fix titles for installing the pulumi CLI

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,4 +1,4 @@
-name: Run Template Tests Against Latest CLI
+name: Run Template Tests Against Pulumi CLI
 on:
   schedule:
     - cron: '0 8 * * *'
@@ -64,7 +64,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Install Latest Pulumi CLI
+      - name: Install Pulumi CLI
         uses: pulumi/actions@v5
         with:
           pulumi-version: ${{ matrix.pulumi-version }}

--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -96,7 +96,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0
         with:
           install_components: gke-gcloud-auth-plugin
-      - name: Install Latest Pulumi CLI
+      - name: Install Pulumi CLI
         uses: pulumi/actions@v5
         with:
           pulumi-version: dev


### PR DESCRIPTION
The titles currently mention "Latest" pulumi CLI, however that's easily confused as the latest stable release, even though we are installing the dev versions now.

/cc @justinvp who noticed this