### PR TITLE
Bump @pulumi/aiven from 5.4.0 to 6.11.0

### DIFF
--- a/aiven-typescript/package.json
+++ b/aiven-typescript/package.json
@@ -6,6 +6,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.20.0",
-        "@pulumi/aiven": "^5.4.0"
+        "@pulumi/aiven": "^6.11.0"
     }
 }


### PR DESCRIPTION
The template didn't work because it uses an old version of the Aiven provider.

```
Previewing update (testcluster):
     Type                  Name                       Plan       Info
 +   pulumi:pulumi:Stack   hpi-aiven-iac-testcluster  create     1 error; 35 messages
 +   └─ aiven:index:Kafka  kafka1                     create     1 error

Diagnostics:
  pulumi:pulumi:Stack (hpi-aiven-iac-testcluster):
    2024/02/13 15:40:35 [DEBUG] Creating an instance of kafkaTopicCache ...
    panic: value is null
    goroutine 16 [running]:
    github.com/hashicorp/go-cty/cty.Value.LengthInt({{{0x0?, 0x0?}}, {0x0?, 0x0?}})
        /home/runner/go/pkg/mod/github.com/hashicorp/go-cty@v1.4.1-0.20200414143053-d3edf31b6320/cty/value_ops.go:989 +0x250
    github.com/hashicorp/go-cty/cty.Value.AsValueMap({{{0x0?, 0x0?}}, {0x0?, 0x0?}})
        /home/runner/go/pkg/mod/github.com/hashicorp/go-cty@v1.4.1-0.20200414143053-d3edf31b6320/cty/value_ops.go:1237 +0x64
    github.com/aiven/terraform-provider-aiven/internal/schemautil.CustomizeDiffDisallowMultipleManyToOneKeys({0x14000228800?, 0x1400095a730?}, 0x140007c7b30?, {0x140007c7b00?, 0x1400095e5e0?})
        /home/runner/work/pulumi-aiven/pulumi-aiven/upstream/internal/schemautil/custom_diff.go:231 +0x2c
    github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff.Sequence.func1({0x105653158, 0x140001a4010}, 0x10517e778?, {0x1055c3c80, 0x14000277680})
        /home/runner/go/pkg/mod/github.com/pulumi/terraform-plugin-sdk/v2@v2.0.0-20221122203342-430f685de305/helper/customdiff/compose.go:67 +0x80
    github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.schemaMap.Diff(0x14000503890, {0x105653158, 0x140001a4010}, 0x0, 0x140004b9cb0, 0x14000733460, {0x1055c3c80, 0x14000277680}, 0x0)
        /home/runner/go/pkg/mod/github.com/pulumi/terraform-plugin-sdk/v2@v2.0.0-20221122203342-430f685de305/helper/schema/schema.go:699 +0x3c4
    github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).SimpleDiff(0x0?, {0x105653158?, 0x140001a4010?}, 0x0, 0x0?, {0x1055c3c80?, 0x14000277680?})
        /home/runner/go/pkg/mod/github.com/pulumi/terraform-plugin-sdk/v2@v2.0.0-20221122203342-430f685de305/helper/schema/resource.go:895 +0x50
    github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2.v2Provider.simpleDiff({0x1054b0fe0?, {0x14000735e60?, 0x10517bc02?, 0xb?}}, 0x0?, 0xffffffffffffffff?, 0x1400063b4b8?, 0x10515011c?, {{{0x105653d28?, 0x140000fc3f0?}}, ...}, ...)
        /home/runner/go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/v3@v3.42.1/pkg/tfshim/sdk-v2/provider_diff.go:73 +0x56c
    github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2.v2Provider.Diff({0x1400009c120?, {0x0?, 0x0?, 0x1400063b6b8?}}, {0x10517bc02, 0xb}, {0x0?, 0x0}, {0x10564bf20, 0x140004b9cb0})
        /home/runner/go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/v3@v3.42.1/pkg/tfshim/sdk-v2/provider_diff.go:54 +0x200
    github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge.(*Provider).Create(0x140004dec80, {0x1056531c8?, 0x140004e3fb0?}, 0x1400051e370)
        /home/runner/go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/v3@v3.42.1/pkg/tfbridge/provider.go:873 +0x2c8
    github.com/pulumi/pulumi/sdk/v3/proto/go._ResourceProvider_Create_Handler.func1({0x1056531c8, 0x140004e3fb0}, {0x1055a4740?, 0x1400051e370})
        /home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.56.0/proto/go/provider_grpc.pb.go:573 +0x74
    github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc.OpenTracingServerInterceptor.func1({0x1056531c8, 0x140004e3b90}, {0x1055a4740, 0x1400051e370}, 0x140000f1560, 0x140001eb1a0)
        /home/runner/go/pkg/mod/github.com/grpc-ecosystem/grpc-opentracing@v0.0.0-20180507213350-8e809c8a8645/go/otgrpc/server.go:57 +0x2f4
    github.com/pulumi/pulumi/sdk/v3/proto/go._ResourceProvider_Create_Handler({0x105615d80?, 0x140004dec80}, {0x1056531c8, 0x140004e3b90}, 0x14000457180, 0x14000733d20)
        /home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.56.0/proto/go/provider_grpc.pb.go:575 +0x12c
    google.golang.org/grpc.(*Server).processUnaryRPC(0x140003e0000, {0x1056596a0, 0x140006024e0}, 0x1400037bd40, 0x1400061c180, 0x105fa6b60, 0x0)
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.53.0/server.go:1336 +0xb38
    google.golang.org/grpc.(*Server).handleStream(0x140003e0000, {0x1056596a0, 0x140006024e0}, 0x1400037bd40, 0x0)
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.53.0/server.go:1704 +0x80c
    google.golang.org/grpc.(*Server).serveStreams.func1.2()
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.53.0/server.go:965 +0x84
    created by google.golang.org/grpc.(*Server).serveStreams.func1
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.53.0/server.go:963 +0x278
```