### PR TITLE
Use get_int for configuration values

### DIFF
--- a/container-gcp-python/__main__.py
+++ b/container-gcp-python/__main__.py
@@ -11,7 +11,7 @@ image_name = config.get("imageName", "my-app")
 container_port = config.get_int("containerPort", 8080)
 cpu = config.get_int("cpu", 1)
 memory = config.get("memory", "1Gi")
-concurrency = config.get_float("concurrency", 50)
+concurrency = config.get_int("concurrency", 50)
 
 # Import the provider's configuration settings.
 gcp_config = pulumi.Config("gcp")

--- a/kubernetes-aws-python/__main__.py
+++ b/kubernetes-aws-python/__main__.py
@@ -4,9 +4,9 @@ import pulumi_eks as eks
 
 # Get some values from the Pulumi configuration (or use defaults)
 config = pulumi.Config()
-min_cluster_size = config.get_float("minClusterSize", 3)
-max_cluster_size = config.get_float("maxClusterSize", 6)
-desired_cluster_size = config.get_float("desiredClusterSize", 3)
+min_cluster_size = config.get_int("minClusterSize", 3)
+max_cluster_size = config.get_int("maxClusterSize", 6)
+desired_cluster_size = config.get_int("desiredClusterSize", 3)
 eks_node_instance_type = config.get("eksNodeInstanceType", "t3.medium")
 vpc_network_cidr = config.get("vpcNetworkCidr", "10.0.0.0/16")
 

--- a/kubernetes-gcp-python/__main__.py
+++ b/kubernetes-gcp-python/__main__.py
@@ -7,7 +7,7 @@ gcp_project = provider_cfg.require("project")
 gcp_region = provider_cfg.get("region", "us-central1")
 # Get some additional configuration values
 config = pulumi.Config()
-nodes_per_zone = config.get_float("nodesPerZone", 1)
+nodes_per_zone = config.get_int("nodesPerZone", 1)
 
 # Create a new network
 gke_network = gcp.compute.Network(

--- a/webapp-kubernetes-python/__main__.py
+++ b/webapp-kubernetes-python/__main__.py
@@ -4,7 +4,7 @@ import pulumi_kubernetes as kubernetes
 # Get some values from the Pulumi stack configuration, or use defaults
 config = pulumi.Config()
 k8sNamespace = config.get("namespace", "default")
-numReplicas = config.get_float("replicas", 1)
+numReplicas = config.get_int("replicas", 1)
 app_labels = {
     "app": "nginx",
 }


### PR DESCRIPTION
This PR replaces instances of `get_float` with `get_int` when pulling integer-based configuration values for Python templates.

Fixes https://github.com/pulumi/templates/issues/677