### PR TITLE
update Go version to 1.21.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-8core-2022]
-        go-version: [1.20.x]
+        go-version: [1.21.x]
         node-version: [18.x]
         python-version: [3.8]
         dotnet: [6.0.x]

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-8core-2022]
-        go-version: [1.20.x]
+        go-version: [1.21.x]
         node-version: [18.x]
         python-version: [3.8]
         dotnet: [6.0.x]

--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        go-version: [1.20.x]
+        go-version: [1.21.x]
         node-version: [18.x]
         python-version: [3.8]
         dotnet: [6.0.x]

--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-8core-2022]
-        go-version: [1.20.x]
+        go-version: [1.21.x]
         node-version: [18.x]
         python-version: [3.8]
         dotnet: [6.0.x]


### PR DESCRIPTION
pulumi/pulumi generally supports the two latest Go releases.  Since 1.22.x came out, we dropped support for 1.20.x, and indeed compilation of the latest pulumi/pulumi source is failing with the latest Go version because of the missing `slices` package.

Update CI to the latest supported Go version, so we are able to update pulumi/pulumi in this repo.

(I need to update to the latest pulumi/pulumi to get dev SDKs tested, work for that is in https://github.com/pulumi/templates/pull/756.  But this feels separate enough to warrant a separate PR.)

We will also need to update the required CI jobs as the name changes based on the versions of the various toolchains.  I'm not an admin in this repo, so I can't do that myself unfortunately. (Or maybe we could make only the sentinel job required, since that doesn't change, so would be more future proof)