### PR TITLE
Remove unnecessary import

### DIFF
--- a/container-gcp-python/__main__.py
+++ b/container-gcp-python/__main__.py
@@ -1,7 +1,6 @@
 import pulumi
 import pulumi_docker as docker
-from pulumi_gcp import cloudrun, config as gcp_config
-from pulumi_gcp import artifactregistry
+from pulumi_gcp import artifactregistry, cloudrun
 import pulumi_random as random
 
 # Import the program's configuration settings.


### PR DESCRIPTION
An import from pulumi_gcp.config(gcp_config) was being done for no reason and could actually cause some confusion as the same var was overwritten later.

Use a single import line for all gcp imports