### PR TITLE
free up disk space before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,11 @@ jobs:
           repo: gotesttools/gotestfmt
       - name: Get dependencies
         run: make ensure
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          swap-storage: false
       - if: contains(matrix.platform, 'windows')
         name: Running Windows tests
         shell: bash

--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -119,6 +119,11 @@ jobs:
           repo: gotesttools/gotestfmt
       - name: Get dependencies
         run: make ensure
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          swap-storage: false      - if: contains(matrix.platform, 'windows')
       - if: contains(matrix.platform, 'windows')
         name: Running Windows tests
         shell: bash

--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -123,7 +123,7 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
-          swap-storage: false      - if: contains(matrix.platform, 'windows')
+          swap-storage: false
       - if: contains(matrix.platform, 'windows')
         name: Running Windows tests
         shell: bash


### PR DESCRIPTION
These tests seem to occasionally run out of disk space.  Free up some space before running them to avoid that.