### PR TITLE
ci: Use the latest dev version for cron runs

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -37,7 +37,7 @@ jobs:
         python-version: [3.8]
         dotnet: [6.0.x]
         pulumi-version:
-          - latest
+          - dev
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: read


### PR DESCRIPTION
We're already using the dev version for PRs and performance cron runs, but aren't currently for this cron workflow. Which means I generally have to look at recent PRs to see how dev builds are doing before publishing a new pulumi/pulumi release. This PR updates the cron workflow to use the dev release.