### PR TITLE
Update TypeScript templates to include TypeScript 5 and target ES2020

### DIFF
--- a/aiven-typescript/package.json
+++ b/aiven-typescript/package.json
@@ -5,7 +5,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.20.0",
-        "@pulumi/aiven": "^5.4.0"
+        "@pulumi/aiven": "^5.4.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/aiven-typescript/tsconfig.json
+++ b/aiven-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/alicloud-typescript/package.json
+++ b/alicloud-typescript/package.json
@@ -5,7 +5,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/alicloud": "^3.0.0"
+        "@pulumi/alicloud": "^3.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/alicloud-typescript/tsconfig.json
+++ b/alicloud-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/auth0-typescript/package.json
+++ b/auth0-typescript/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "${PROJECT}",
-  "main": "index.ts",
-  "devDependencies": {
-    "@types/node": "^18"
-  },
-  "dependencies": {
-    "@pulumi/pulumi": "^3.20.0",
-    "@pulumi/auth0": "^2.3.2"
-  }
+    "name": "${PROJECT}",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18"
+    },
+    "dependencies": {
+        "@pulumi/auth0": "^2.3.2",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
+    }
 }

--- a/auth0-typescript/tsconfig.json
+++ b/auth0-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/aws-native-typescript/package.json
+++ b/aws-native-typescript/package.json
@@ -5,7 +5,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/aws-native": "^0.8.0"
+        "@pulumi/aws-native": "^0.8.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/aws-native-typescript/tsconfig.json
+++ b/aws-native-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/aws-typescript/package.json
+++ b/aws-typescript/package.json
@@ -5,8 +5,9 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
         "@pulumi/aws": "^6.0.0",
-        "@pulumi/awsx": "^2.0.2"
+        "@pulumi/awsx": "^2.0.2",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/aws-typescript/tsconfig.json
+++ b/aws-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/azure-classic-typescript/package.json
+++ b/azure-classic-typescript/package.json
@@ -5,7 +5,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/azure": "^5.0.0"
+        "@pulumi/azure": "^5.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/azure-classic-typescript/tsconfig.json
+++ b/azure-classic-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/azure-typescript/package.json
+++ b/azure-typescript/package.json
@@ -5,7 +5,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/azure-native": "^2.0.0"
+        "@pulumi/azure-native": "^2.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/azure-typescript/tsconfig.json
+++ b/azure-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/civo-typescript/package.json
+++ b/civo-typescript/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "${PROJECT}",
-  "main": "index.ts",
-  "devDependencies": {
-    "@types/node": "^18"
-  },
-  "dependencies": {
-    "@pulumi/pulumi": "3.60.0",
-    "@pulumi/civo": "2.3.4"
-  }
+    "name": "${PROJECT}",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18"
+    },
+    "dependencies": {
+        "@pulumi/civo": "2.3.4",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
+    }
 }

--- a/civo-typescript/tsconfig.json
+++ b/civo-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/container-aws-typescript/package.json
+++ b/container-aws-typescript/package.json
@@ -1,12 +1,12 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-	    "@types/node": "^18"
+        "@types/node": "^18"
     },
     "dependencies": {
-	    "typescript": "^4.0.0",
-	    "@pulumi/pulumi": "^3.0.0",
-	    "@pulumi/aws": "^6.0.0",
-	    "@pulumi/awsx": "^2.0.2"
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/awsx": "^2.0.2",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/container-aws-typescript/tsconfig.json
+++ b/container-aws-typescript/tsconfig.json
@@ -1,18 +1,18 @@
 {
-		"compilerOptions": {
-			"strict": true,
-			"outDir": "bin",
-			"target": "es2016",
-			"module": "commonjs",
-			"moduleResolution": "node",
-			"sourceMap": true,
-			"experimentalDecorators": true,
-			"pretty": true,
-			"noFallthroughCasesInSwitch": true,
-			"noImplicitReturns": true,
-			"forceConsistentCasingInFileNames": true
-		},
-		"files": [
-			"index.ts"
-		]
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2020",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts"
+	]
 }

--- a/container-azure-typescript/package.json
+++ b/container-azure-typescript/package.json
@@ -6,7 +6,8 @@
     "dependencies": {
         "@pulumi/azure-native": "^2.0.0",
         "@pulumi/docker": "^4.2.3",
-        "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/random": "^4.8.2"
+        "@pulumi/random": "^4.8.2",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/container-azure-typescript/tsconfig.json
+++ b/container-azure-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/container-gcp-typescript/package.json
+++ b/container-gcp-typescript/package.json
@@ -7,7 +7,8 @@
     "dependencies": {
         "@pulumi/docker": "^4.2.3",
         "@pulumi/gcp": "^7.0.0",
-        "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/random": "^4.0.0"
+        "@pulumi/random": "^4.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/container-gcp-typescript/tsconfig.json
+++ b/container-gcp-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/digitalocean-typescript/package.json
+++ b/digitalocean-typescript/package.json
@@ -5,7 +5,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/digitalocean": "^4.0.0"
+        "@pulumi/digitalocean": "^4.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/digitalocean-typescript/tsconfig.json
+++ b/digitalocean-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/equinix-metal-typescript/package.json
+++ b/equinix-metal-typescript/package.json
@@ -5,7 +5,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/equinix-metal": "^2.0.0"
+        "@pulumi/equinix-metal": "^2.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/equinix-metal-typescript/tsconfig.json
+++ b/equinix-metal-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/gcp-typescript/package.json
+++ b/gcp-typescript/package.json
@@ -5,7 +5,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/gcp": "^7.0.0"
+        "@pulumi/gcp": "^7.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/gcp-typescript/tsconfig.json
+++ b/gcp-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/github-typescript/package.json
+++ b/github-typescript/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "${PROJECT}",
-  "main": "index.ts",
-  "devDependencies": {
-    "@types/node": "^18"
-  },
-  "dependencies": {
-    "@pulumi/pulumi": "^3.19.0",
-    "@pulumi/github": "^4.8.1"
-  }
+    "name": "${PROJECT}",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18"
+    },
+    "dependencies": {
+        "@pulumi/github": "^4.8.1",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
+    }
 }

--- a/github-typescript/tsconfig.json
+++ b/github-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/google-native-typescript/package.json
+++ b/google-native-typescript/package.json
@@ -5,7 +5,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.1.0",
-        "@pulumi/google-native": "^0.7.0"
+        "@pulumi/google-native": "^0.7.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/google-native-typescript/tsconfig.json
+++ b/google-native-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/helm-kubernetes-typescript/package.json
+++ b/helm-kubernetes-typescript/package.json
@@ -4,8 +4,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "typescript": "^4.0.0",
-        "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/kubernetes": "^4.0.0"
+        "@pulumi/kubernetes": "^4.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/helm-kubernetes-typescript/tsconfig.json
+++ b/helm-kubernetes-typescript/tsconfig.json
@@ -1,18 +1,18 @@
 {
-		"compilerOptions": {
-			"strict": true,
-			"outDir": "bin",
-			"target": "es2016",
-			"module": "commonjs",
-			"moduleResolution": "node",
-			"sourceMap": true,
-			"experimentalDecorators": true,
-			"pretty": true,
-			"noFallthroughCasesInSwitch": true,
-			"noImplicitReturns": true,
-			"forceConsistentCasingInFileNames": true
-		},
-		"files": [
-			"index.ts"
-		]
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2020",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts"
+	]
 }

--- a/kubernetes-aws-typescript/package.json
+++ b/kubernetes-aws-typescript/package.json
@@ -4,9 +4,9 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "typescript": "^4.0.0",
-        "@pulumi/pulumi": "^3.0.0",
         "@pulumi/awsx": "^2.0.2",
-        "@pulumi/eks": "^v2.0.0"
+        "@pulumi/eks": "^v2.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/kubernetes-aws-typescript/tsconfig.json
+++ b/kubernetes-aws-typescript/tsconfig.json
@@ -1,18 +1,18 @@
 {
-		"compilerOptions": {
-			"strict": true,
-			"outDir": "bin",
-			"target": "es2016",
-			"module": "commonjs",
-			"moduleResolution": "node",
-			"sourceMap": true,
-			"experimentalDecorators": true,
-			"pretty": true,
-			"noFallthroughCasesInSwitch": true,
-			"noImplicitReturns": true,
-			"forceConsistentCasingInFileNames": true
-		},
-		"files": [
-			"index.ts"
-		]
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2020",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts"
+	]
 }

--- a/kubernetes-azure-typescript/package.json
+++ b/kubernetes-azure-typescript/package.json
@@ -5,7 +5,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/azure-native": "^2.0.0"
+        "@pulumi/azure-native": "^2.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/kubernetes-azure-typescript/tsconfig.json
+++ b/kubernetes-azure-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/kubernetes-gcp-typescript/package.json
+++ b/kubernetes-gcp-typescript/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "${PROJECT}",
-  "devDependencies": {
-    "@types/node": "^18"
-  },
-  "dependencies": {
-    "typescript": "^4.0.0",
-    "@pulumi/pulumi": "^3.0.0",
-    "@pulumi/gcp": "^7.0.0"
-  }
+    "name": "${PROJECT}",
+    "devDependencies": {
+        "@types/node": "^18"
+    },
+    "dependencies": {
+        "@pulumi/gcp": "^7.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
+    }
 }

--- a/kubernetes-gcp-typescript/tsconfig.json
+++ b/kubernetes-gcp-typescript/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "outDir": "bin",
-    "target": "es2016",
+    "target": "es2020",
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,

--- a/kubernetes-typescript/package.json
+++ b/kubernetes-typescript/package.json
@@ -5,7 +5,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/kubernetes": "^4.0.0"
+        "@pulumi/kubernetes": "^4.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/kubernetes-typescript/tsconfig.json
+++ b/kubernetes-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/linode-typescript/package.json
+++ b/linode-typescript/package.json
@@ -5,7 +5,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/linode": "^4.0.0"
+        "@pulumi/linode": "^4.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/linode-typescript/tsconfig.json
+++ b/linode-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/oci-typescript/package.json
+++ b/oci-typescript/package.json
@@ -5,7 +5,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "3.60.0",
-        "@pulumi/oci": "0.13.0"
+        "@pulumi/oci": "0.13.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/oci-typescript/tsconfig.json
+++ b/oci-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/openstack-typescript/package.json
+++ b/openstack-typescript/package.json
@@ -5,7 +5,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/openstack": "^3.0.0"
+        "@pulumi/openstack": "^3.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/openstack-typescript/tsconfig.json
+++ b/openstack-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/pinecone-typescript/package.json
+++ b/pinecone-typescript/package.json
@@ -5,7 +5,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
-        "@pinecone-database/pulumi": "^0.3.0"
+        "@pinecone-database/pulumi": "^0.3.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/pinecone-typescript/tsconfig.json
+++ b/pinecone-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/random-typescript/package.json
+++ b/random-typescript/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "${PROJECT}",
-  "main": "index.ts",
-  "devDependencies": {
-    "@types/node": "^18"
-  },
-  "dependencies": {
-    "@pulumi/pulumi": "^3.19.0",
-    "@pulumi/random": "^4.13.0"
-  }
+    "name": "${PROJECT}",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18"
+    },
+    "dependencies": {
+        "@pulumi/random": "^4.13.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
+    }
 }

--- a/random-typescript/tsconfig.json
+++ b/random-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/scaleway-typescript/package.json
+++ b/scaleway-typescript/package.json
@@ -5,7 +5,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "3.60.0",
-        "@lbrlabs/pulumi-scaleway": "1.7.0"
+        "@lbrlabs/pulumi-scaleway": "1.7.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/scaleway-typescript/tsconfig.json
+++ b/scaleway-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/serverless-aws-typescript/package.json
+++ b/serverless-aws-typescript/package.json
@@ -1,13 +1,13 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-	    "@types/node": "^18"
+        "@types/node": "^18"
     },
     "dependencies": {
-	    "@pulumi/aws": "^6.0.0",
-	    "@pulumi/aws-apigateway": "^2.0.0",
-	    "@pulumi/awsx": "^2.0.2",
-	    "@pulumi/pulumi": "^3.49.0",
-	    "typescript": "^4.6.2"
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/aws-apigateway": "^2.0.0",
+        "@pulumi/awsx": "^2.0.2",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/serverless-aws-typescript/tsconfig.json
+++ b/serverless-aws-typescript/tsconfig.json
@@ -1,18 +1,18 @@
 {
-		"compilerOptions": {
-			"strict": true,
-			"outDir": "bin",
-			"target": "es2016",
-			"module": "commonjs",
-			"moduleResolution": "node",
-			"sourceMap": true,
-			"experimentalDecorators": true,
-			"pretty": true,
-			"noFallthroughCasesInSwitch": true,
-			"noImplicitReturns": true,
-			"forceConsistentCasingInFileNames": true
-		},
-		"files": [
-			"index.ts"
-		]
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2020",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts"
+	]
 }

--- a/serverless-azure-typescript/package.json
+++ b/serverless-azure-typescript/package.json
@@ -4,9 +4,9 @@
         "@types/node": "^18"
     },
     "dependencies": {
-    "@pulumi/azure-native": "^2.0.0",
-    "@pulumi/pulumi": "^3.49.0",
-    "@pulumi/synced-folder": "^0.0.9",
-    "typescript": "^4.0.0"
+        "@pulumi/azure-native": "^2.0.0",
+        "@pulumi/synced-folder": "^0.0.9",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
 	}
 }

--- a/serverless-azure-typescript/tsconfig.json
+++ b/serverless-azure-typescript/tsconfig.json
@@ -1,18 +1,18 @@
 {
-		"compilerOptions": {
-			"strict": true,
-			"outDir": "bin",
-			"target": "es2016",
-			"module": "commonjs",
-			"moduleResolution": "node",
-			"sourceMap": true,
-			"experimentalDecorators": true,
-			"pretty": true,
-			"noFallthroughCasesInSwitch": true,
-			"noImplicitReturns": true,
-			"forceConsistentCasingInFileNames": true
-		},
-		"files": [
-			"index.ts"
-		]
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2020",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts"
+	]
 }

--- a/serverless-gcp-typescript/package.json
+++ b/serverless-gcp-typescript/package.json
@@ -6,7 +6,8 @@
     },
     "dependencies": {
         "@pulumi/gcp": "^7.0.0",
-        "@pulumi/pulumi": "^3.49.0",
-        "@pulumi/synced-folder": "^0.0.9"
+        "@pulumi/synced-folder": "^0.0.9",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/serverless-gcp-typescript/tsconfig.json
+++ b/serverless-gcp-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/static-website-aws-typescript/package.json
+++ b/static-website-aws-typescript/package.json
@@ -5,8 +5,8 @@
     },
     "dependencies": {
         "@pulumi/aws": "^6.0.2",
-        "@pulumi/pulumi": "^3.49.0",
         "@pulumi/synced-folder": "^0.0.9",
-        "typescript": "^4.0.0"
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/static-website-aws-typescript/tsconfig.json
+++ b/static-website-aws-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/static-website-azure-typescript/package.json
+++ b/static-website-azure-typescript/package.json
@@ -5,8 +5,8 @@
     },
     "dependencies": {
         "@pulumi/azure-native": "^2.0.0",
-        "@pulumi/pulumi": "^3.0.0",
         "@pulumi/synced-folder": "^0.0.9",
-        "typescript": "^4.0.0"
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/static-website-azure-typescript/tsconfig.json
+++ b/static-website-azure-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/static-website-gcp-typescript/package.json
+++ b/static-website-gcp-typescript/package.json
@@ -5,8 +5,8 @@
     },
     "dependencies": {
         "@pulumi/gcp": "^7.0.0",
-        "@pulumi/pulumi": "^3.49.0",
         "@pulumi/synced-folder": "^0.0.9",
-        "typescript": "^4.0.0"
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/static-website-gcp-typescript/tsconfig.json
+++ b/static-website-gcp-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -5,6 +5,7 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0"
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/vm-aws-typescript/package.json
+++ b/vm-aws-typescript/package.json
@@ -4,8 +4,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "typescript": "^4.0.0",
-        "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/aws": "^6.0.2"
+        "@pulumi/aws": "^6.0.2",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/vm-aws-typescript/tsconfig.json
+++ b/vm-aws-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/vm-azure-typescript/package.json
+++ b/vm-azure-typescript/package.json
@@ -6,8 +6,9 @@
     },
     "dependencies": {
         "@pulumi/azure-native": "^2.0.0",
-        "@pulumi/pulumi": "^3.0.0",
         "@pulumi/random": "^4.8.2",
-        "@pulumi/tls": "^4.0.0"
+        "@pulumi/tls": "^4.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/vm-azure-typescript/tsconfig.json
+++ b/vm-azure-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/vm-gcp-typescript/package.json
+++ b/vm-gcp-typescript/package.json
@@ -5,7 +5,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/gcp": "^7.0.0"
+        "@pulumi/gcp": "^7.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/vm-gcp-typescript/tsconfig.json
+++ b/vm-gcp-typescript/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "bin",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/webapp-kubernetes-typescript/package.json
+++ b/webapp-kubernetes-typescript/package.json
@@ -4,8 +4,8 @@
         "@types/node": "^18"
     },
     "dependencies": {
-        "typescript": "^4.0.0",
-        "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/kubernetes": "^4.0.0"
+        "@pulumi/kubernetes": "^4.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/webapp-kubernetes-typescript/tsconfig.json
+++ b/webapp-kubernetes-typescript/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "outDir": "bin",
-    "target": "es2016",
+    "target": "es2020",
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,


### PR DESCRIPTION
## Bump target to ES2020

Our minimum supported version of node and TypeScript both fully support ES2020 (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#es2020-for-target-and-module, https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0cebe5d5bcaad4a8f18e525b1cd098583b252585/types/node/v18/index.d.ts#L28C5-L28C31)

## Include TypeScript 5

We now fully support TypeScript 5 https://github.com/pulumi/pulumi/pull/15622. To make Pulumi use it instead of the bundled TS 3.8.3, it needs to be set as a dependency.