### PR TITLE
fix(kubernetes): Bump default version for k8s on azure

### DIFF
--- a/kubernetes-azure-csharp/Pulumi.yaml
+++ b/kubernetes-azure-csharp/Pulumi.yaml
@@ -14,7 +14,7 @@ template:
       default: pulumi
       description: DNS prefix for the cluster
     kubernetesVersion:
-      default: 1.26.3
+      default: 1.26.10
       description: Kubernetes version to deploy in the cluster
     nodeVmSize:
       default: Standard_DS2_v2

--- a/kubernetes-azure-go/Pulumi.yaml
+++ b/kubernetes-azure-go/Pulumi.yaml
@@ -14,7 +14,7 @@ template:
       default: pulumi
       description: DNS prefix for the cluster
     kubernetesVersion:
-      default: 1.26.3
+      default: 1.26.10
       description: Kubernetes version to deploy in the cluster
     nodeVmSize:
       default: Standard_DS2_v2

--- a/kubernetes-azure-python/Pulumi.yaml
+++ b/kubernetes-azure-python/Pulumi.yaml
@@ -14,7 +14,7 @@ template:
       default: pulumi
       description: DNS prefix for the cluster
     kubernetesVersion:
-      default: 1.26.3
+      default: 1.26.10
       description: Kubernetes version to deploy in the cluster
     nodeVmSize:
       default: Standard_DS2_v2

--- a/kubernetes-azure-typescript/Pulumi.yaml
+++ b/kubernetes-azure-typescript/Pulumi.yaml
@@ -14,7 +14,7 @@ template:
       default: pulumi
       description: DNS prefix for the cluster
     kubernetesVersion:
-      default: 1.26.3
+      default: 1.26.10
       description: Kubernetes version to deploy in the cluster
     nodeVmSize:
       default: Standard_DS2_v2


### PR DESCRIPTION
Fixes: #781 

Bump to a supported version.

Maybe it should have a bigger bump though? 1.29.2 is the most recent supported release.
