### PR TITLE
Move TypeScript to devDependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           install_components: gke-gcloud-auth-plugin
       - name: Install gotestfmt
-        uses: jaxxstorm/action-install-gh-release@v1.9.0
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
         with:
           repo: gotesttools/gotestfmt
       - name: Get dependencies

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           install_components: gke-gcloud-auth-plugin
       - name: Install gotestfmt
-        uses: jaxxstorm/action-install-gh-release@v1.9.0
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
         with:
           repo: gotesttools/gotestfmt
       - name: Get dependencies

--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -71,7 +71,7 @@ jobs:
           pip3 install virtualenv==20.0.23
           pip3 install pipenv
       - name: Install gotestfmt
-        uses: jaxxstorm/action-install-gh-release@v1.9.0
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
         with:
           repo: gotesttools/gotestfmt
       - uses: actions/checkout@v3

--- a/.github/workflows/run-templates-command.yml
+++ b/.github/workflows/run-templates-command.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           install_components: gke-gcloud-auth-plugin
       - name: Install gotestfmt
-        uses: jaxxstorm/action-install-gh-release@v1.9.0
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
         with:
           repo: gotesttools/gotestfmt
       - name: Get dependencies

--- a/aiven-typescript/package.json
+++ b/aiven-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/aiven": "^5.4.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/alicloud-typescript/package.json
+++ b/alicloud-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/alicloud": "^3.0.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/auth0-typescript/package.json
+++ b/auth0-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/auth0": "^2.3.2",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/aws-native-typescript/package.json
+++ b/aws-native-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/aws-native": "^0.8.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/aws-typescript/package.json
+++ b/aws-typescript/package.json
@@ -2,12 +2,12 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/aws": "^6.0.0",
         "@pulumi/awsx": "^2.0.2",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/azure-classic-typescript/package.json
+++ b/azure-classic-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/azure": "^5.0.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/azure-typescript/package.json
+++ b/azure-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/azure-native": "^2.0.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/civo-typescript/package.json
+++ b/civo-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/civo": "2.3.4",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/container-aws-typescript/package.json
+++ b/container-aws-typescript/package.json
@@ -1,12 +1,12 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/aws": "^6.0.0",
         "@pulumi/awsx": "^2.0.2",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/container-azure-typescript/package.json
+++ b/container-azure-typescript/package.json
@@ -1,13 +1,13 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/azure-native": "^2.0.0",
         "@pulumi/docker": "^4.2.3",
         "@pulumi/random": "^4.8.2",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/container-gcp-typescript/package.json
+++ b/container-gcp-typescript/package.json
@@ -2,13 +2,13 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/docker": "^4.2.3",
         "@pulumi/gcp": "^7.0.0",
         "@pulumi/random": "^4.0.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/digitalocean-typescript/package.json
+++ b/digitalocean-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/digitalocean": "^4.0.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/equinix-metal-typescript/package.json
+++ b/equinix-metal-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/equinix-metal": "^2.0.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/gcp-typescript/package.json
+++ b/gcp-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/gcp": "^7.0.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/github-typescript/package.json
+++ b/github-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/github": "^4.8.1",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/google-native-typescript/package.json
+++ b/google-native-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/google-native": "^0.7.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/helm-kubernetes-typescript/package.json
+++ b/helm-kubernetes-typescript/package.json
@@ -1,11 +1,11 @@
 {
     "name": "test",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/kubernetes": "^4.0.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/kubernetes-aws-typescript/package.json
+++ b/kubernetes-aws-typescript/package.json
@@ -1,12 +1,12 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/awsx": "^2.0.2",
         "@pulumi/eks": "^v2.0.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/kubernetes-azure-typescript/package.json
+++ b/kubernetes-azure-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/azure-native": "^2.0.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/kubernetes-gcp-typescript/package.json
+++ b/kubernetes-gcp-typescript/package.json
@@ -1,11 +1,11 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/gcp": "^7.0.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/kubernetes-typescript/package.json
+++ b/kubernetes-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/kubernetes": "^4.0.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/linode-typescript/package.json
+++ b/linode-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/linode": "^4.0.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/oci-typescript/package.json
+++ b/oci-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/oci": "0.13.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/openstack-typescript/package.json
+++ b/openstack-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/openstack": "^3.0.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/pinecone-typescript/package.json
+++ b/pinecone-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pinecone-database/pulumi": "^0.3.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/random-typescript/package.json
+++ b/random-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/random": "^4.13.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/scaleway-typescript/package.json
+++ b/scaleway-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "scaleway-typescript",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@lbrlabs/pulumi-scaleway": "1.7.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/serverless-aws-typescript/package.json
+++ b/serverless-aws-typescript/package.json
@@ -1,13 +1,13 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/aws": "^6.0.0",
         "@pulumi/aws-apigateway": "^2.0.0",
         "@pulumi/awsx": "^2.0.2",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/serverless-azure-typescript/package.json
+++ b/serverless-azure-typescript/package.json
@@ -1,12 +1,12 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/azure-native": "^2.0.0",
         "@pulumi/synced-folder": "^0.0.9",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
 	}
 }

--- a/serverless-gcp-typescript/package.json
+++ b/serverless-gcp-typescript/package.json
@@ -2,12 +2,12 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/gcp": "^7.0.0",
         "@pulumi/synced-folder": "^0.0.9",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/static-website-aws-typescript/package.json
+++ b/static-website-aws-typescript/package.json
@@ -1,12 +1,12 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/aws": "^6.0.2",
         "@pulumi/synced-folder": "^0.0.9",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/static-website-azure-typescript/package.json
+++ b/static-website-azure-typescript/package.json
@@ -1,12 +1,12 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/azure-native": "^2.0.0",
         "@pulumi/synced-folder": "^0.0.9",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/static-website-gcp-typescript/package.json
+++ b/static-website-gcp-typescript/package.json
@@ -1,12 +1,12 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/gcp": "^7.0.0",
         "@pulumi/synced-folder": "^0.0.9",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -2,10 +2,10 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/vm-aws-typescript/package.json
+++ b/vm-aws-typescript/package.json
@@ -1,11 +1,11 @@
 {
     "name": "${PROJECT}",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/aws": "^6.0.2",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/vm-azure-typescript/package.json
+++ b/vm-azure-typescript/package.json
@@ -2,13 +2,13 @@
     "name": "vm-azure-typescript",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/azure-native": "^2.0.0",
         "@pulumi/random": "^4.8.2",
         "@pulumi/tls": "^4.0.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/vm-gcp-typescript/package.json
+++ b/vm-gcp-typescript/package.json
@@ -2,11 +2,11 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/gcp": "^7.0.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }

--- a/webapp-kubernetes-typescript/package.json
+++ b/webapp-kubernetes-typescript/package.json
@@ -1,11 +1,11 @@
 {
     "name": "webapp-kubernetes-typescript",
     "devDependencies": {
-        "@types/node": "^18"
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/kubernetes": "^4.0.0",
-        "@pulumi/pulumi": "^3.113.0",
-        "typescript": "^5.0.0"
+        "@pulumi/pulumi": "^3.113.0"
     }
 }


### PR DESCRIPTION
We don't want magic functions to include typescript as a dependency.

In https://github.com/pulumi/templates/pull/774 we added TypeScript as an explicit dependency so that new projects use a recent version of TypeScript by default. However listing it in `dependencies` instead of `devDependencies` causes magic functions to bundle it. We avoid this by making it a devDependency.