### PR TITLE
Fix typo in Kubernetes YAML architecture template

### DIFF
--- a/kubernetes-gcp-yaml/Pulumi.yaml
+++ b/kubernetes-gcp-yaml/Pulumi.yaml
@@ -71,7 +71,7 @@ resources:
         workloadPool: ${gcp:project}.svc.id.goog
   # Create a new service account for the nodepool
   gke-nodepool-sa:
-    type: gcp:serviceAccount:Account
+    type: gcp:serviceaccount:Account
     properties:
       accountId: ${gke-cluster.name}-np-1-sa
       displayName: Nodepool 1 Service Account


### PR DESCRIPTION
The template currently contains a typo that results in the following error:

```
Diagnostics:
  pulumi:pulumi:Stack (kubernetes-gcp-yaml-72f8d81-dev):
    Error: error resolving type of resource gke-nodepool-sa: unable to find resource type "gcp:serviceAccount:Account" in resource provider "gcp"
      on Pulumi.yaml line 79:
      79:     type: gcp:serviceAccount:Account
```

Should be `serviceaccount`, not `serviceAccount`.

Fixes #793.
