### PR TITLE
Upgrades stale version of synced-folder component

### DIFF
--- a/static-website-aws-typescript/package.json
+++ b/static-website-aws-typescript/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^6.0.2",
-        "@pulumi/synced-folder": "^0.0.9",
+        "@pulumi/synced-folder": "^0.11.1",
         "@pulumi/pulumi": "^3.113.0"
     }
 }


### PR DESCRIPTION
Per user reported bug, this version is stale and causes errors.

Testing this depends on: #844 so merge after that.