### PR TITLE
Add unit tests to aws-typescript

### DIFF
--- a/aws-typescript/index.ts
+++ b/aws-typescript/index.ts
@@ -1,9 +1,4 @@
-import * as pulumi from "@pulumi/pulumi";
-import * as aws from "@pulumi/aws";
-import * as awsx from "@pulumi/awsx";
+import * as infra from "./infra";
 
-// Create an AWS resource (S3 Bucket)
-const bucket = new aws.s3.BucketV2("my-bucket");
-
-// Export the name of the bucket
-export const bucketName = bucket.id;
+// Export the name of the bucket.
+export const bucketName = infra.bucket.id;

--- a/aws-typescript/infra.ts
+++ b/aws-typescript/infra.ts
@@ -1,0 +1,10 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
+
+// Create an AWS resource (S3 Bucket) with tags.
+export const bucket = new aws.s3.BucketV2("my-bucket", {
+    tags: {
+        "Name": "My bucket",
+    },
+});

--- a/aws-typescript/jest.config.js
+++ b/aws-typescript/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} **/
+module.exports = {
+    testEnvironment: "node",
+    transform: {
+        "^.+.tsx?$": ["ts-jest", {}],
+    },
+};

--- a/aws-typescript/package.json
+++ b/aws-typescript/package.json
@@ -2,12 +2,18 @@
     "name": "${PROJECT}",
     "main": "index.ts",
     "devDependencies": {
+        "@types/jest": "^29.5.14",
         "@types/node": "^18",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.2.5",
         "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/aws": "^6.0.0",
         "@pulumi/awsx": "^2.0.2",
         "@pulumi/pulumi": "^3.113.0"
+    },
+    "scripts": {
+        "test": "jest"
     }
 }

--- a/aws-typescript/tests/infra.spec.ts
+++ b/aws-typescript/tests/infra.spec.ts
@@ -1,0 +1,51 @@
+import * as pulumi from "@pulumi/pulumi";
+import "jest";
+
+// Test helper to convert a Pulumi Output to a Promise.
+// This should only be used in tests.
+function promiseOf<T>(output: pulumi.Output<T>): Promise<T> {
+    return new Promise(resolve => output.apply(resolve));
+}
+
+describe("infrastructure", () => {
+    // Define the infra variable as a type whose shape matches the that of the
+    // to-be-defined infra module.
+    let infra: typeof import("../infra");
+
+    beforeAll(() => {
+        // Put Pulumi in unit-test mode, mocking all calls to cloud-provider APIs.
+        pulumi.runtime.setMocks({
+            // Mock calls to create new resources and return a canned response.
+            newResource: (args: pulumi.runtime.MockResourceArgs) => {
+                // Here, we're returning a same-shaped object for all resource types.
+                // We could, however, use the arguments passed into this function to
+                // customize the mocked-out properties of a particular resource.
+                // See the unit-testing docs for details:
+                // https://www.pulumi.com/docs/iac/concepts/testing/unit/
+                return {
+                    id: `${args.name}-id`,
+                    state: args.inputs,
+                };
+            },
+
+            // Mock function calls and return an empty response.
+            call: (args: pulumi.runtime.MockCallArgs) => {
+                return {};
+            },
+        });
+    });
+
+    beforeEach(async () => {
+        // Dynamically import the infra module.
+        infra = await import("../infra");
+    });
+
+    // Example test. To run, uncomment and run `npm test`.
+    // describe("bucket", () => {
+    //     it("must have a name tag", async () => {
+    //         const tags = await promiseOf(infra.bucket.tags);
+    //         expect(tags).toBeDefined();
+    //         expect(tags).toHaveProperty("Name");
+    //     });
+    // });
+});

--- a/aws-typescript/tsconfig.json
+++ b/aws-typescript/tsconfig.json
@@ -11,8 +11,5 @@
         "noFallthroughCasesInSwitch": true,
         "noImplicitReturns": true,
         "forceConsistentCasingInFileNames": true
-    },
-    "files": [
-        "index.ts"
-    ]
+    }
 }


### PR DESCRIPTION
This change updates the `aws-typescript` template to include unit tests using jest. (Once we're happy with this, I'll add the moral equivalent for `aws-javascript` in a separate PR).