### PR TITLE
Add unit tests to aws-go

### DIFF
--- a/aws-go/go.mod
+++ b/aws-go/go.mod
@@ -5,4 +5,5 @@ go 1.20
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.37.1
 	github.com/pulumi/pulumi/sdk/v3 v3.117.0
+	github.com/stretchr/testify v1.9.0
 )

--- a/aws-go/main.go
+++ b/aws-go/main.go
@@ -5,16 +5,35 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
+type infrastructure struct {
+	bucket *s3.BucketV2
+}
+
+func createInfrastructure(ctx *pulumi.Context) (*infrastructure, error) {
+	// Create an AWS resource (S3 Bucket) with tags.
+	bucket, err := s3.NewBucketV2(ctx, "my-bucket", &s3.BucketV2Args{
+		Tags: pulumi.StringMap{
+			"Name": pulumi.String("My bucket"),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &infrastructure{
+		bucket: bucket,
+	}, nil
+}
+
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		// Create an AWS resource (S3 Bucket)
-		bucket, err := s3.NewBucketV2(ctx, "my-bucket", nil)
+		infra, err := createInfrastructure(ctx)
 		if err != nil {
 			return err
 		}
 
-		// Export the name of the bucket
-		ctx.Export("bucketName", bucket.ID())
+		// Export the name of the bucket.
+		ctx.Export("bucketName", infra.bucket.ID())
 		return nil
 	})
 }

--- a/aws-go/main_test.go
+++ b/aws-go/main_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+)
+
+type mocks int
+
+// Mock calls to create new resources and return a canned response.
+func (mocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	// Here, we're returning a same-shaped object for all resource types.
+	// We could, however, use the arguments passed into this function to
+	// customize the mocked-out properties of a particular resource.
+	// See the unit-testing docs for details:
+	// https://www.pulumi.com/docs/iac/concepts/testing/unit/
+	return args.Name + "_id", args.Inputs, nil
+}
+
+// Mock function calls and return an empty response.
+func (mocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return resource.PropertyMap{}, nil
+}
+
+func TestInfrastructure(t *testing.T) {
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		var wg sync.WaitGroup
+
+		// Example test. To run, uncomment and run `go test`.
+		// infra, err := createInfrastructure(ctx)
+		// assert.NoError(t, err)
+
+		// wg.Add(1)
+		// infra.bucket.Tags.ApplyT(func(tags map[string]string) error {
+		// 	assert.NotNil(t, tags)
+		// 	assert.Contains(t, tags, "Name")
+
+		// 	wg.Done()
+		// 	return nil
+		// })
+
+		wg.Wait()
+		return nil
+	}, pulumi.WithMocks("project", "stack", mocks(0)))
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This change updates the `aws-go` template to include unit tests, similar to https://github.com/pulumi/templates/pull/863 for `aws-typescript` and https://github.com/pulumi/templates/pull/864 for `aws-python`.

Part of #865