### PR TITLE
[WIP] custom jest output matchers

### DIFF
--- a/aws-typescript/jest.config.js
+++ b/aws-typescript/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
     transform: {
         "^.+.tsx?$": ["ts-jest", {}],
     },
+    setupFilesAfterEnv: ['./jest.matchers.js'],
 };

--- a/aws-typescript/jest.matchers.js
+++ b/aws-typescript/jest.matchers.js
@@ -1,0 +1,45 @@
+const { Output } = require("@pulumi/pulumi")
+
+expect.extend({
+    async toEqualOutputOf(actual, expected) {
+        if (!actual instanceof Output) {
+            throw new Error(`Actual value must be an Output, got ${typeof actual}`)
+        }
+        return new Promise(resolve =>
+            actual.apply(unwrapped => {
+                if (this.equals(unwrapped, expected)) {
+                    resolve({
+                        pass: true,
+                    })
+                } else {
+                    resolve({
+                        message: () => `expected ${this.utils.printExpected(expected)} to equal ${this.utils.printReceived(unwrapped)}`,
+                        pass: false,
+                    })
+                }
+            })
+        )
+    },
+
+    async apply(actual, applyFn) {
+        if (!actual instanceof Output) {
+            throw new Error(`Actual value must be an Output, got ${typeof actual}`)
+        }
+        return new Promise(resolve =>
+            actual.apply(async (...args) => {
+                try {
+                    await applyFn(...args)
+                    resolve({
+                        pass: true,
+                    })
+                } catch (e) {
+                    resolve({
+                        message: () => e.message,
+                        pass: false,
+                    })
+                }
+            })
+        )
+    },
+
+})

--- a/aws-typescript/tests/infra.spec.ts
+++ b/aws-typescript/tests/infra.spec.ts
@@ -41,11 +41,20 @@ describe("infrastructure", () => {
     });
 
     // Example test. To run, uncomment and run `npm test`.
-    // describe("bucket", () => {
-    //     it("must have a name tag", async () => {
-    //         const tags = await promiseOf(infra.bucket.tags);
-    //         expect(tags).toBeDefined();
-    //         expect(tags).toHaveProperty("Name");
-    //     });
-    // });
+    describe("bucket", () => {
+        it("must have a name tag", async () => {
+            const tags = await promiseOf(infra.bucket.tags);
+            expect(tags).toBeDefined();
+            expect(tags).toHaveProperty("Name");
+        });
+        it("must have the right tags", async () => {
+            await (expect(infra.bucket.tags) as any).toEqualOutputOf({ "Name": "My bucket oops" })
+        })
+        it("some apply thing", async () => {
+            await (expect(infra.bucket.tags) as any).apply((tags: any) => {
+                expect(tags).toBeDefined();
+                expect(tags).toHaveProperty("Name2");
+            })
+        })
+    });
 });


### PR DESCRIPTION
This shows a custom jest test matchers that know about Outputs.

`expect(...).apply(applyFn)` takes a callback that's meant to work like `Output.apply`. Internally it translates to a promise for jest so we don't have to deal with `done()`.

`expect(...).toEqualOutputOf(...)` can be used to easily check the resolved value of an output.

We could ship these matchers in a `@pulumi/jest-matchers` library.
