### PR TITLE
  static-website-aws-yaml bugfix: swap key and suffix

### DIFF
--- a/static-website-aws-yaml/Pulumi.yaml
+++ b/static-website-aws-yaml/Pulumi.yaml
@@ -40,9 +40,9 @@ resources:
     properties:
       bucket: ${bucket.bucket}
       errorDocument:
-        suffix: ${errorDocument}
+        key: ${errorDocument}
       indexDocument:
-        key: ${indexDocument}
+        suffix: ${indexDocument}
     type: aws:s3:BucketWebsiteConfigurationV2
 
   # Assign ownership controls to the new S3 bucket


### PR DESCRIPTION
Error with existing template:

```
Diagnostics:
  pulumi:pulumi:Stack (pulumi-example):
    Error: aws:s3/bucketWebsiteConfigurationV2:BucketWebsiteConfigurationV2 is not assignable from {bucket: string, errorDocument: {suffix: string}, indexDocument: {key: string}}
    Cannot assign '{bucket: string, errorDocument: {suffix: string}, indexDocument: {key: string}}' to 'aws:s3/bucketWebsiteConfigurationV2:BucketWebsiteConfigurationV2':
      errorDocument: Cannot assign '{suffix: string}' to 'aws:s3/BucketWebsiteConfigurationV2ErrorDocument:BucketWebsiteConfigurationV2ErrorDocument':
        key: Missing required property 'key'
        Existing properties are: key
      indexDocument: Cannot assign '{key: string}' to 'aws:s3/BucketWebsiteConfigurationV2IndexDocument:BucketWebsiteConfigurationV2IndexDocument':
        suffix: Missing required property 'suffix'
        Existing properties are: suffix
```

For the BucketWebsiteConfigurationV2 resource:

- `errorDocument` requires a `key` property (not `suffix`)
- `indexDocument` requires a `suffix` property (not `key`)

https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketwebsiteconfigurationv2/