### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/build-metadata.yml
+++ b/.github/workflows/build-metadata.yml
@@ -1,3 +1,10 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-templates
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: Build template metadata
 on:
   push:
@@ -8,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Build
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Install Node
         uses: actions/setup-node@v3
         with:
@@ -16,7 +26,7 @@ jobs:
       - name: Check out branch
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
 
       - name: Build metadata
         run: |

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -1,3 +1,10 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-templates
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: Commmand dispatch for testing
 on:
   issue_comment:
@@ -9,11 +16,14 @@ jobs:
   command-dispatch-for-testing:
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@v3
       - name: Run Build
         uses: peter-evans/slash-command-dispatch@v2
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          token: ${{ steps.esc-secrets.outputs.REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           commands: run-templates
           permission: write

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: Test templates
 on:
   push:
@@ -17,23 +18,20 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PULUMI_TEST_OWNER: "moolumi"
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   AWS_REGION: "us-west-2"
   GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-ci-gcp-provider.iam.gserviceaccount.com
   GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
   GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
   GOOGLE_PROJECT: pulumi-ci-gcp-provider
   GOOGLE_PROJECT_NUMBER: 895284651812
-  LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
   SKIPPED_TESTS: "alicloud,digitalocean,kubernetes,openstack,equinix-metal,aiven,auth0,github,oci,java-jbang,java-gradle,azuredevops,vm-azure,ovh-java,aws-scala"
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_VERSION: ${{ github.event.client_payload.ref }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   ESC_ACTION_OIDC_AUTH: true
   ESC_ACTION_OIDC_ORGANIZATION: pulumi
   ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
-  ESC_ACTION_ENVIRONMENT: imports/github-secrets
-  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: ARM_CLIENT_ID,ARM_CLIENT_SECRET,ARM_TENANT_ID,ARM_SUBSCRIPTION_ID
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-templates
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: PULUMI_ACCESS_TOKEN,LINODE_TOKEN,SLACK_WEBHOOK_URL,ARM_CLIENT_ID,ARM_CLIENT_SECRET,ARM_SUBSCRIPTION_ID,ARM_TENANT_ID
   AZURE_LOCATION: westus
   TESTPARALLELISM: 10
   PULUMI_TEMPLATE_LOCATION: ${{ github.workspace}}
@@ -70,6 +68,9 @@ jobs:
       id-token: write
 
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - if: contains(matrix.platform, 'ubuntu')
         name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
@@ -146,7 +147,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-duration-seconds: 14400 # 4 hours
           role-session-name: templates@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -191,7 +192,6 @@ jobs:
           cd tests && go test -v -json -count=1 -cover -timeout 1h -parallel ${{ env.TESTPARALLELISM }} . 2>&1 | gotestfmt
         env:
           TESTPARALLELISM: 6
-
 
       - if: 'failure()'
         name: Notify Slack

--- a/.github/workflows/update-templates.yml
+++ b/.github/workflows/update-templates.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: Upgrade templates
 on:
   workflow_dispatch: {}
@@ -6,13 +7,20 @@ on:
       - update-templates
 
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-templates
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 
 jobs:
   build:
     name: Update Templates
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
       - name: Update Template Versions
@@ -34,10 +42,10 @@ jobs:
           destination_branch: "master"
           pr_title: "Update Go template dependencies to their latest versions"
           pr_body: "This PR was generated automatically, most likely in response to a [pulumi/pulumi release](https://github.com/pulumi/pulumi/releases)."
-          github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: Close superseded upgrade PRs
         env:
-          GH_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+          GH_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           NEW_BRANCH: templates/${{ github.run_id }}-${{ github.run_number }}
         run: |
           new_pr=$(gh pr view "$NEW_BRANCH" --json number --jq .number)


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.
