### PR TITLE
[aws-java] Fix com.pulumi.aws version range

### DIFF
--- a/aws-java/pom.xml
+++ b/aws-java/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.pulumi</groupId>
             <artifactId>aws</artifactId>
-            <version>[6.68,7.0]</version>
+            <version>[6.68,6.999)</version>
         </dependency>
     </dependencies>
 

--- a/aws-java/pom.xml
+++ b/aws-java/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.pulumi</groupId>
             <artifactId>aws</artifactId>
-            <version>[6.68,6.999)</version>
+            <version>[6.68,6.999]</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
We just released [v7.0.0-alpha.1](https://github.com/pulumi/pulumi-aws/releases/tag/v7.0.0-alpha.1) of the AWS provider. Our aws-java template sets a version range of `[6.68,7.0]` for the dependency, and so now we're pulling in the alpha. However there is an issue with this version as `BucketV2` seems to be gone (I don't think that's intentional). In any case, we don't want to use the alpha version here.

We need to update the version range in the template, but using `[6.68,7.0)` (note the `)`) does not do what you'd think [^1]. We need to set it to something like `[6.68,6.999]`.

We should check all of our other java templates for similar issues.

Fixes https://github.com/pulumi/pulumi-docker-containers/issues/494

[^1]: https://michakutz.medium.com/legit-but-useless-maven-version-ranges-explained-d4ba66ac654