### PR TITLE
Updating NodeJS to 22 (LTS version)

### DIFF
--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -50,7 +50,7 @@ jobs:
         go-version:
           - 1.21.x
         node-version:
-          - 18.x
+          - 22.x
         python-version:
           - 3.9
         dotnet-version:


### PR DESCRIPTION
The [current](https://nodejs.org/en/about/previous-releases#looking-for-the-latest-release-of-a-version-branch) LTS version for NodeJS is 22. Updating to that version.