### PR TITLE
Update generate-go-mod.sh

### DIFF
--- a/generator/mod-templates/aiven-template.txt
+++ b/generator/mod-templates/aiven-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi-aiven/sdk/v6 ${VERSION}

--- a/generator/mod-templates/alicloud-template.txt
+++ b/generator/mod-templates/alicloud-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi-alicloud/sdk/v3 ${VERSION}

--- a/generator/mod-templates/auth0-template.txt
+++ b/generator/mod-templates/auth0-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi-auth0/sdk/v2 ${VERSION}

--- a/generator/mod-templates/aws-native-template.txt
+++ b/generator/mod-templates/aws-native-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi-aws-native/sdk ${VERSION}

--- a/generator/mod-templates/aws-template.txt
+++ b/generator/mod-templates/aws-template.txt
@@ -1,8 +1,8 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 ${VERSION}
+	github.com/pulumi/pulumi-aws/sdk/v7 ${VERSION}
 	github.com/pulumi/pulumi/sdk/v3 ${PULUMI_VERSION}
 )

--- a/generator/mod-templates/azure-classic-template.txt
+++ b/generator/mod-templates/azure-classic-template.txt
@@ -1,8 +1,8 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
-	github.com/pulumi/pulumi-azure/sdk/v5 ${VERSION}
+	github.com/pulumi/pulumi-azure/sdk/v6 ${VERSION}
 	github.com/pulumi/pulumi/sdk/v3 ${PULUMI_VERSION}
 )

--- a/generator/mod-templates/azure-template.txt
+++ b/generator/mod-templates/azure-template.txt
@@ -1,9 +1,9 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
-	github.com/pulumi/pulumi-azure-native-sdk/resources/v2 ${VERSION}
-    github.com/pulumi/pulumi-azure-native-sdk/storage/v2 ${VERSION}
+	github.com/pulumi/pulumi-azure-native-sdk/resources/v3 ${VERSION}
+    github.com/pulumi/pulumi-azure-native-sdk/storage/v3 ${VERSION}
 	github.com/pulumi/pulumi/sdk/v3 ${PULUMI_VERSION}
 )

--- a/generator/mod-templates/civo-template.txt
+++ b/generator/mod-templates/civo-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi-civo/sdk/v2 ${VERSION}

--- a/generator/mod-templates/digitalocean-template.txt
+++ b/generator/mod-templates/digitalocean-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi-digitalocean/sdk/v4 ${VERSION}

--- a/generator/mod-templates/equinix-metal-template.txt
+++ b/generator/mod-templates/equinix-metal-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi-equinix-metal/sdk/v3 ${VERSION}

--- a/generator/mod-templates/gcp-template.txt
+++ b/generator/mod-templates/gcp-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi-gcp/sdk/v8 ${VERSION}

--- a/generator/mod-templates/github-template.txt
+++ b/generator/mod-templates/github-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi-github/sdk/v5 ${VERSION}

--- a/generator/mod-templates/go-template.txt
+++ b/generator/mod-templates/go-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi/sdk/v3 ${PULUMI_VERSION}

--- a/generator/mod-templates/google-native-template.txt
+++ b/generator/mod-templates/google-native-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi-google-native/sdk ${VERSION}

--- a/generator/mod-templates/kubernetes-template.txt
+++ b/generator/mod-templates/kubernetes-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi-kubernetes/sdk/v4 ${VERSION}

--- a/generator/mod-templates/linode-template.txt
+++ b/generator/mod-templates/linode-template.txt
@@ -1,8 +1,8 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
-	github.com/pulumi/pulumi-linode/sdk/v4 ${VERSION}
+	github.com/pulumi/pulumi-linode/sdk/v5 ${VERSION}
 	github.com/pulumi/pulumi/sdk/v3 ${PULUMI_VERSION}
 )

--- a/generator/mod-templates/oci-template.txt
+++ b/generator/mod-templates/oci-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi-oci/sdk ${VERSION}

--- a/generator/mod-templates/openstack-template.txt
+++ b/generator/mod-templates/openstack-template.txt
@@ -1,6 +1,6 @@
 module ${PROJECT}
 
-go 1.20
+go 1.23
 
 require (
 	github.com/pulumi/pulumi-openstack/sdk/v3 ${VERSION}


### PR DESCRIPTION
Set the Go version to 1.23, this is the minimum version the latest Go SDK supports.

Also update some templates (aws, azure, azure-classic, linode) to account for major version bumps.

That should fix the pulumi-bot auto-updates for Go templates. There's currently 68 stale PRs for this https://github.com/pulumi/templates/pulls/pulumi-bot ... Once this is merged, I'll close out those PRs and run the job to re-generate a new PR that should then merge cleanly.