### PR TITLE
fix go.mod generator for azure-native and run it

### DIFF
--- a/aiven-go/go.mod
+++ b/aiven-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.23
 
 require (
-	github.com/pulumi/pulumi-aiven/sdk/v6 v6.43.0
-	github.com/pulumi/pulumi/sdk/v3 v3.198.0
+	github.com/pulumi/pulumi-aiven/sdk/v6 v6.43.1
+	github.com/pulumi/pulumi/sdk/v3 v3.199.0
 )

--- a/alicloud-go/go.mod
+++ b/alicloud-go/go.mod
@@ -4,5 +4,5 @@ go 1.23
 
 require (
 	github.com/pulumi/pulumi-alicloud/sdk/v3 v3.86.1
-	github.com/pulumi/pulumi/sdk/v3 v3.198.0
+	github.com/pulumi/pulumi/sdk/v3 v3.199.0
 )

--- a/auth0-go/go.mod
+++ b/auth0-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.23
 
 require (
-	github.com/pulumi/pulumi-auth0/sdk/v3 v3.28.0
-	github.com/pulumi/pulumi/sdk/v3 v3.198.0
+	github.com/pulumi/pulumi-auth0/sdk/v3 v3.29.0
+	github.com/pulumi/pulumi/sdk/v3 v3.199.0
 )

--- a/aws-go/go.mod
+++ b/aws-go/go.mod
@@ -4,5 +4,5 @@ go 1.23
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v7 v7.7.0
-	github.com/pulumi/pulumi/sdk/v3 v3.198.0
+	github.com/pulumi/pulumi/sdk/v3 v3.199.0
 )

--- a/azure-classic-go/go.mod
+++ b/azure-classic-go/go.mod
@@ -4,5 +4,5 @@ go 1.23
 
 require (
 	github.com/pulumi/pulumi-azure/sdk/v6 v6.26.0
-	github.com/pulumi/pulumi/sdk/v3 v3.198.0
+	github.com/pulumi/pulumi/sdk/v3 v3.199.0
 )

--- a/azure-go/go.mod
+++ b/azure-go/go.mod
@@ -3,6 +3,7 @@ module ${PROJECT}
 go 1.23
 
 require (
-	github.com/pulumi/pulumi-azure-native/sdk/v3 v3.8.0
-	github.com/pulumi/pulumi/sdk/v3 v3.198.0
+	github.com/pulumi/pulumi-azure-native-sdk/resources/v3 v3.8.0
+	github.com/pulumi/pulumi-azure-native-sdk/storage/v3 v3.8.0
+	github.com/pulumi/pulumi/sdk/v3 v3.199.0
 )

--- a/civo-go/go.mod
+++ b/civo-go/go.mod
@@ -4,5 +4,5 @@ go 1.23
 
 require (
 	github.com/pulumi/pulumi-civo/sdk/v2 v2.4.8
-	github.com/pulumi/pulumi/sdk/v3 v3.198.0
+	github.com/pulumi/pulumi/sdk/v3 v3.199.0
 )

--- a/digitalocean-go/go.mod
+++ b/digitalocean-go/go.mod
@@ -4,5 +4,5 @@ go 1.23
 
 require (
 	github.com/pulumi/pulumi-digitalocean/sdk/v4 v4.53.0
-	github.com/pulumi/pulumi/sdk/v3 v3.198.0
+	github.com/pulumi/pulumi/sdk/v3 v3.199.0
 )

--- a/equinix-metal-go/go.mod
+++ b/equinix-metal-go/go.mod
@@ -4,5 +4,5 @@ go 1.23
 
 require (
 	github.com/pulumi/pulumi-equinix-metal/sdk/v3 v3.2.1
-	github.com/pulumi/pulumi/sdk/v3 v3.198.0
+	github.com/pulumi/pulumi/sdk/v3 v3.199.0
 )

--- a/gcp-go/go.mod
+++ b/gcp-go/go.mod
@@ -3,6 +3,6 @@ module ${PROJECT}
 go 1.23
 
 require (
-	github.com/pulumi/pulumi-gcp/sdk/v9 v9.1.0
-	github.com/pulumi/pulumi/sdk/v3 v3.198.0
+	github.com/pulumi/pulumi-gcp/sdk/v9 v9.2.0
+	github.com/pulumi/pulumi/sdk/v3 v3.199.0
 )

--- a/generator/generate-go-mod.sh
+++ b/generator/generate-go-mod.sh
@@ -36,13 +36,20 @@ for i in "${PROVIDERS[@]}"; do
 			MAJOR_VERSION="/v$major_num"
 		fi
 	fi
+	REQUIRE_LINE="github.com/pulumi/pulumi-${PROVIDER_NAME}/sdk${MAJOR_VERSION} ${PROVIDER_VERSION}"
+	if [ "$PROVIDER_NAME" = "azure-native" ]; then
+		# azure-native has a different internal structure. Generate the go.mod file accordingly.
+		REQUIRE_LINE="github.com/pulumi/pulumi-azure-native-sdk/resources${MAJOR_VERSION} ${PROVIDER_VERSION}
+	github.com/pulumi/pulumi-azure-native-sdk/storage${MAJOR_VERSION} ${PROVIDER_VERSION}"
+	fi
+
         cat<<EOF > "../$i-go/go.mod"
 module \${PROJECT}
 
 go ${GO_VERSION}
 
 require (
-	github.com/pulumi/pulumi-${PROVIDER_NAME}/sdk${MAJOR_VERSION} ${PROVIDER_VERSION}
+	${REQUIRE_LINE}
 	github.com/pulumi/pulumi/sdk/v3 ${PULUMI_VERSION}
 )
 EOF

--- a/go/go.mod
+++ b/go/go.mod
@@ -3,5 +3,5 @@ module ${PROJECT}
 go 1.23
 
 require (
-	github.com/pulumi/pulumi/sdk/v3 v3.198.0
+	github.com/pulumi/pulumi/sdk/v3 v3.199.0
 )

--- a/google-native-go/go.mod
+++ b/google-native-go/go.mod
@@ -4,5 +4,5 @@ go 1.23
 
 require (
 	github.com/pulumi/pulumi-google-native/sdk v0.32.0
-	github.com/pulumi/pulumi/sdk/v3 v3.198.0
+	github.com/pulumi/pulumi/sdk/v3 v3.199.0
 )

--- a/kubernetes-go/go.mod
+++ b/kubernetes-go/go.mod
@@ -4,5 +4,5 @@ go 1.23
 
 require (
 	github.com/pulumi/pulumi-kubernetes/sdk/v4 v4.23.0
-	github.com/pulumi/pulumi/sdk/v3 v3.198.0
+	github.com/pulumi/pulumi/sdk/v3 v3.199.0
 )

--- a/linode-go/go.mod
+++ b/linode-go/go.mod
@@ -4,5 +4,5 @@ go 1.23
 
 require (
 	github.com/pulumi/pulumi-linode/sdk/v5 v5.3.0
-	github.com/pulumi/pulumi/sdk/v3 v3.198.0
+	github.com/pulumi/pulumi/sdk/v3 v3.199.0
 )

--- a/oci-go/go.mod
+++ b/oci-go/go.mod
@@ -4,5 +4,5 @@ go 1.23
 
 require (
 	github.com/pulumi/pulumi-oci/sdk/v3 v3.9.0
-	github.com/pulumi/pulumi/sdk/v3 v3.198.0
+	github.com/pulumi/pulumi/sdk/v3 v3.199.0
 )

--- a/openstack-go/go.mod
+++ b/openstack-go/go.mod
@@ -4,5 +4,5 @@ go 1.23
 
 require (
 	github.com/pulumi/pulumi-openstack/sdk/v5 v5.3.3
-	github.com/pulumi/pulumi/sdk/v3 v3.198.0
+	github.com/pulumi/pulumi/sdk/v3 v3.199.0
 )


### PR DESCRIPTION
The azure-native SDK is split into multpile modules. When we updated the go.mod generator in https://github.com/pulumi/templates/pull/961, we missed that fact, and broke the azure-native templates go.mod. Fix that.

Fixes https://github.com/pulumi/pulumi-docker-containers/issues/549