### PR TITLE
Remove toolchain directives from go templates

### DIFF
--- a/container-aws-go/go.mod
+++ b/container-aws-go/go.mod
@@ -2,8 +2,6 @@ module ${PROJECT}
 
 go 1.23.0
 
-toolchain go1.24.2
-
 require (
 	github.com/pulumi/pulumi-aws/sdk/v7 v7.0.0
 	github.com/pulumi/pulumi-awsx/sdk/v3 v3.0.0

--- a/container-azure-go/go.mod
+++ b/container-azure-go/go.mod
@@ -2,8 +2,6 @@ module ${PROJECT}
 
 go 1.21.7
 
-toolchain go1.22.1
-
 require (
 	github.com/pulumi/pulumi-azure-native-sdk/containerinstance/v2 v2.1.1
 	github.com/pulumi/pulumi-azure-native-sdk/containerregistry/v2 v2.1.1

--- a/container-gcp-go/go.mod
+++ b/container-gcp-go/go.mod
@@ -2,8 +2,6 @@ module ${PROJECT}
 
 go 1.21.7
 
-toolchain go1.22.1
-
 require (
 	github.com/pulumi/pulumi-docker-build/sdk/go/dockerbuild v0.0.6
 	github.com/pulumi/pulumi-gcp/sdk/v9 v9.0.0

--- a/serverless-aws-go/go.mod
+++ b/serverless-aws-go/go.mod
@@ -2,8 +2,6 @@ module ${PROJECT}
 
 go 1.23.0
 
-toolchain go1.24.2
-
 require (
 	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.0.0
 	github.com/pulumi/pulumi-aws/sdk/v7 v7.0.0

--- a/static-website-aws-go/go.mod
+++ b/static-website-aws-go/go.mod
@@ -2,8 +2,6 @@ module ${PROJECT}
 
 go 1.23.0
 
-toolchain go1.24.2
-
 require (
 	github.com/pulumi/pulumi-aws/sdk/v7 v7.0.0
 	github.com/pulumi/pulumi-synced-folder/sdk v0.12.4

--- a/vm-aws-go/go.mod
+++ b/vm-aws-go/go.mod
@@ -2,8 +2,6 @@ module ${PROJECT}
 
 go 1.23.0
 
-toolchain go1.24.2
-
 require (
 	github.com/pulumi/pulumi-aws/sdk/v7 v7.0.0
 	github.com/pulumi/pulumi/sdk/v3 v3.175.0


### PR DESCRIPTION
These shouldn't be necessary for templates. Also, update CI to use the oldest supported version of go (1.24.x).