### PR TITLE
Remove `azure-classic` from the go mod updator

### DIFF
--- a/generator/generate-go-mod.sh
+++ b/generator/generate-go-mod.sh
@@ -16,14 +16,12 @@ fetch_latest_version() {
 
 PULUMI_VERSION="$(fetch_latest_version pulumi)"
 
-PROVIDER_LIST="aiven,alicloud,auth0,aws,azure,azure-classic,civo,digitalocean,equinix-metal,gcp,google-native,kubernetes,linode,oci,openstack,random"
+PROVIDER_LIST="aiven,alicloud,auth0,aws,azure,civo,digitalocean,equinix-metal,gcp,google-native,kubernetes,linode,oci,openstack,random"
 IFS=',' read -ra PROVIDERS <<<"$PROVIDER_LIST"
 
 for i in "${PROVIDERS[@]}"; do
 	echo "Updating $i template"
-	if [ "$i" = "azure-classic" ]; then
-		PROVIDER_NAME="azure"
-	elif [ "$i" = "azure" ]; then
+        if [ "$i" = "azure" ]; then
 		PROVIDER_NAME="azure-native"
 	else
 		PROVIDER_NAME="$i"

--- a/tests/perf/performance_test.go
+++ b/tests/perf/performance_test.go
@@ -126,10 +126,6 @@ func guessRuntime(template workspace.Template) string {
 }
 
 func guessProvider(template workspace.Template) string {
-	if strings.Contains(template.Name, "azure-classic") {
-		return "azure-classic"
-	}
-
 	if strings.Contains(template.Name, "azure") {
 		return "azure"
 	}


### PR DESCRIPTION
`azure-classic` templates were removed in https://github.com/pulumi/templates/pull/1013.

Fixes https://github.com/pulumi/templates/issues/1018.