### PR TITLE
Upgrade Kubernetes version for Azure

### DIFF
--- a/kubernetes-azure-csharp/Program.cs
+++ b/kubernetes-azure-csharp/Program.cs
@@ -9,7 +9,7 @@ return await Pulumi.Deployment.RunAsync(() =>
     // Grab some values from the Pulumi stack configuration (or use defaults)
     var projCfg = new Config();
     var numWorkerNodes = projCfg.GetInt32("numWorkerNodes") ?? 3;
-    var k8sVersion = projCfg.Get("kubernetesVersion") ?? "1.32";
+    var k8sVersion = projCfg.Get("kubernetesVersion") ?? "1.33";
     var prefixForDns = projCfg.Get("prefixForDns") ?? "pulumi";
     var nodeVmSize = projCfg.Get("nodeVmSize") ?? "Standard_DS2_v2";
 

--- a/kubernetes-azure-csharp/Pulumi.yaml
+++ b/kubernetes-azure-csharp/Pulumi.yaml
@@ -14,7 +14,7 @@ template:
       default: pulumi
       description: DNS prefix for the cluster
     kubernetesVersion:
-      default: 1.32.7
+      default: "1.33"
       description: Kubernetes version to deploy in the cluster
     nodeVmSize:
       default: Standard_DS2_v2

--- a/kubernetes-azure-go/Pulumi.yaml
+++ b/kubernetes-azure-go/Pulumi.yaml
@@ -14,7 +14,7 @@ template:
       default: pulumi
       description: DNS prefix for the cluster
     kubernetesVersion:
-      default: 1.32.7
+      default: "1.33"
       description: Kubernetes version to deploy in the cluster
     nodeVmSize:
       default: Standard_DS2_v2

--- a/kubernetes-azure-go/main.go
+++ b/kubernetes-azure-go/main.go
@@ -20,7 +20,7 @@ func main() {
 		}
 		kubernetesVersion, err := cfg.Try("kubernetesVersion")
 		if err != nil {
-			kubernetesVersion = "1.32"
+			kubernetesVersion = "1.33"
 		}
 		numWorkerNodes, err := cfg.TryInt("numWorkerNodes")
 		if err != nil {

--- a/kubernetes-azure-python/Pulumi.yaml
+++ b/kubernetes-azure-python/Pulumi.yaml
@@ -14,7 +14,7 @@ template:
       default: pulumi
       description: DNS prefix for the cluster
     kubernetesVersion:
-      default: 1.32.7
+      default: "1.33"
       description: Kubernetes version to deploy in the cluster
     nodeVmSize:
       default: Standard_DS2_v2

--- a/kubernetes-azure-python/__main__.py
+++ b/kubernetes-azure-python/__main__.py
@@ -9,7 +9,7 @@ from pulumi_azure_native import containerservice
 # Get some project-namespaced configuration values or use default values
 proj_cfg = pulumi.Config()
 num_worker_nodes = proj_cfg.get_int("numWorkerNodes", 3)
-k8s_version = proj_cfg.get("kubernetesVersion", "1.32")
+k8s_version = proj_cfg.get("kubernetesVersion", "1.33")
 prefix_for_dns = proj_cfg.get("prefixForDns", "pulumi")
 node_vm_size = proj_cfg.get("nodeVmSize", "Standard_DS2_v2")
 # The next two configuration values are required (no default can be provided)

--- a/kubernetes-azure-typescript/Pulumi.yaml
+++ b/kubernetes-azure-typescript/Pulumi.yaml
@@ -14,7 +14,7 @@ template:
       default: pulumi
       description: DNS prefix for the cluster
     kubernetesVersion:
-      default: 1.32.7
+      default: "1.33"
       description: Kubernetes version to deploy in the cluster
     nodeVmSize:
       default: Standard_DS2_v2

--- a/kubernetes-azure-typescript/index.ts
+++ b/kubernetes-azure-typescript/index.ts
@@ -6,7 +6,7 @@ import * as containerservice from "@pulumi/azure-native/containerservice";
 // Grab some values from the Pulumi stack configuration (or use defaults)
 const projCfg = new pulumi.Config();
 const numWorkerNodes = projCfg.getNumber("numWorkerNodes") || 3;
-const k8sVersion = projCfg.get("kubernetesVersion") || "1.32";
+const k8sVersion = projCfg.get("kubernetesVersion") || "1.33";
 const prefixForDns = projCfg.get("prefixForDns") || "pulumi";
 const nodeVmSize = projCfg.get("nodeVmSize") || "Standard_DS2_v2";
 // The next two configuration values are required (no default can be provided)

--- a/kubernetes-azure-yaml/Pulumi.yaml
+++ b/kubernetes-azure-yaml/Pulumi.yaml
@@ -13,7 +13,7 @@ template:
       default: pulumi
       description: DNS prefix for the cluster
     kubernetesVersion:
-      default: "1.32"
+      default: "1.33"
       description: Kubernetes version to deploy in the cluster
     nodeVmSize:
       default: Standard_DS2_v2
@@ -34,7 +34,7 @@ config:
     default: pulumi
   kubernetesVersion:
     type: string
-    default: "1.32"
+    default: "1.33"
   nodeVmSize:
     type: string
     default: Standard_DS2_v2


### PR DESCRIPTION
The old Kubernetes versions don't work anymore, so this upgrades the templates to a modern version.

Fixes #781