### PR TITLE
Update the language version matrix

### DIFF
--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -39,7 +39,7 @@ env:
   PULUMI_ENABLE_JOURNALING: "true"
 jobs:
   test:
-    name: Test templates
+    name: ${{ matrix.platform }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
The versions used for the template tests should match the minimum
versions supported by pulumi/pulumi, as defined in https://github.com/pulumi/pulumi/blob/master/scripts/get-job-matrix.py#L145-L152
