### PR TITLE
use type:module for bun templates

### DIFF
--- a/aws-bun/package.json
+++ b/aws-bun/package.json
@@ -1,6 +1,7 @@
 {
     "name": "${PROJECT}",
     "main": "index.ts",
+    "type": "module",
     "devDependencies": {
         "@types/bun": "latest"
     },

--- a/bun/package.json
+++ b/bun/package.json
@@ -1,6 +1,7 @@
 {
     "name": "${PROJECT}",
     "main": "index.ts",
+    "type": "module",
     "devDependencies": {
         "@types/bun": "latest"
     },

--- a/static-website-aws-bun/package.json
+++ b/static-website-aws-bun/package.json
@@ -1,5 +1,7 @@
 {
     "name": "${PROJECT}",
+    "main": "index.ts",
+    "type": "module",
     "devDependencies": {
         "@types/bun": "latest"
     },


### PR DESCRIPTION
Let's make the bun templates use ESM by default, there is no good reason not to with bun, and this better matches projects created via `bun init`.