### PR TITLE
Close superseded upgrade PRs after a new one is opened

### DIFF
--- a/.github/workflows/update-templates.yml
+++ b/.github/workflows/update-templates.yml
@@ -35,3 +35,16 @@ jobs:
           pr_title: "Update Go template dependencies to their latest versions"
           pr_body: "This PR was generated automatically, most likely in response to a [pulumi/pulumi release](https://github.com/pulumi/pulumi/releases)."
           github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
+      - name: Close superseded upgrade PRs
+        env:
+          GH_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+          NEW_BRANCH: templates/${{ github.run_id }}-${{ github.run_number }}
+        run: |
+          new_pr=$(gh pr view "$NEW_BRANCH" --json number --jq .number)
+          gh pr list --state open --author pulumi-bot \
+            --json number,headRefName \
+            --jq ".[] | select(.headRefName != \"$NEW_BRANCH\" and (.headRefName | startswith(\"templates/\"))) | .number" \
+            | while read -r pr; do
+                gh pr close "$pr" --delete-branch \
+                  --comment "Superseded by #${new_pr}."
+              done


### PR DESCRIPTION
## Summary
- After the upgrade-templates workflow opens a new `Update Go template dependencies` PR, close any older open `templates/*` PRs from `pulumi-bot`.
- The closing comment links to the new PR, and `--delete-branch` cleans up the stale source branches.

## Test plan
- [ ] Next scheduled run of `Upgrade templates` opens a fresh PR and closes the previous one with a "Superseded by #N." comment.