### PR TITLE
Remove duplicate ESC-fetch step in test-templates.yml

### DIFF
--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -78,10 +78,6 @@ jobs:
           tool-cache: false
           swap-storage: false
 
-      - name: Fetch secrets from ESC
-        id: esc-secrets
-        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
-
       - name: Install ${{ matrix.java-version }} (${{ matrix.java-distribution }})
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -31,7 +31,7 @@ env:
   ESC_ACTION_OIDC_ORGANIZATION: pulumi
   ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
   ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-templates
-  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: PULUMI_ACCESS_TOKEN,LINODE_TOKEN,SLACK_WEBHOOK_URL,ARM_CLIENT_ID,ARM_CLIENT_SECRET,ARM_SUBSCRIPTION_ID,ARM_TENANT_ID
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: LINODE_TOKEN,SLACK_WEBHOOK_URL,ARM_CLIENT_ID,ARM_CLIENT_SECRET,ARM_SUBSCRIPTION_ID,ARM_TENANT_ID
   AZURE_LOCATION: westus
   TESTPARALLELISM: 10
   PULUMI_TEMPLATE_LOCATION: ${{ github.workspace}}
@@ -71,6 +71,9 @@ jobs:
       - name: Fetch secrets from ESC
         id: esc-secrets
         uses: pulumi/esc-action@v1
+      - name: Use staging Pulumi token
+        shell: bash
+        run: echo "PULUMI_ACCESS_TOKEN=${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN_STAGING }}" >> "$GITHUB_ENV"
       - if: contains(matrix.platform, 'ubuntu')
         name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1


### PR DESCRIPTION
## Summary

The ESC secrets migration in #905 left two `Fetch secrets from ESC` steps with the same `id: esc-secrets` in the `test` job. GitHub Actions rejects duplicate step IDs within a job:

```
gh workflow run test-templates.yml
HTTP 422: failed to parse workflow: (Line: 82, Col: 13): The identifier 'esc-secrets' may not be used more than once within the same scope.
```

This drops the second copy. The first step runs before the Ubuntu disk-space cleanup, which is the intended ordering.

## Test plan

- [ ] `gh workflow run test-templates.yml` no longer 422s
- [ ] CI on this PR runs to completion (jobs are actually scheduled, not zero like the bad parse)