### PR TITLE
Use the reftable backend in test-templates.yml

### DIFF
--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -36,6 +36,12 @@ env:
   TESTPARALLELISM: 10
   PULUMI_TEMPLATE_LOCATION: ${{ github.workspace}}
   PULUMI_ENABLE_JOURNALING: "true"
+  # Use git's reftable backend for new repos (including the bare repos `go get`
+  # creates under $GOMODCACHE/cache/vcs/<hash>/). The `files` backend can't
+  # store refs that differ only in case on case-insensitive filesystems like
+  # macOS APFS, and an aborted fetch leaves orphaned ref locks that break
+  # subsequent parallel `go get -u .../sdk/v3@master` invocations.
+  GIT_DEFAULT_REF_FORMAT: reftable
 jobs:
   test:
     name: ${{ matrix.platform }}


### PR DESCRIPTION
These changes set `GIT_DEFAULT_REF_FORMAT=reftable` on the test-templates workflow to fix an intermittent macOS failure in `TestTemplates/pinecone-go`.

APFS is case-insensitive, pulumi/pulumi has refs that only differ in case, and git's `files` ref backend can't represent that. When `go get -u github.com/pulumi/pulumi/sdk/v3@master` runs, the first `git fetch` aborts with `It is impossible to store such references with the 'files' backend` and leaves orphaned `<ref>.lock` files in `$GOMODCACHE/cache/vcs/<hash>/`. The next parallel `go get` acquires Go's `lockedfile.Mutex` cleanly, runs `git fetch`, and trips on the stale lock. What looked like contention is post-failure cleanup pollution.

The `reftable` backend can store case-conflicting refs on case-insensitive filesystems, so the initial fetch doesn't abort and no orphaned locks are left behind. `go get` shells out to system git, so the workflow env var flows through to the `git init --bare` it runs in the cache dir.

The env var was added in git 2.47; the runner image ships ~2.50.x; reftable becomes the default in git 3.0. GitHub-hosted runners start each job with an empty `$GOMODCACHE`, so no migration is needed. No-op on Linux and Windows.