### PR TITLE
Fix serverless-aws-hcl /date route missing event_handler

### DIFF
--- a/serverless-aws-hcl/main.tf
+++ b/serverless-aws-hcl/main.tf
@@ -40,6 +40,7 @@ resource "aws-apigateway_rest_a_p_i" "api" {
   routes {
     path          = "/date"
     method        = "GET"
+    event_handler = aws_lambda_function.fn
   }
 }
 


### PR DESCRIPTION
Adds the missing `event_handler` wiring the route to the Lambda, matching the other language variants.

👉🏻 Check-suite failures are unrelated BTW.