### PR TITLE
try to fix flaky Go tests

### DIFF
--- a/tests/internal/testutils/environments.go
+++ b/tests/internal/testutils/environments.go
@@ -1,7 +1,14 @@
 package testutils
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -66,8 +73,71 @@ func PrepareProject(t *testing.T, e *ptesting.Environment) func(*engine.Projinfo
 		prepareProject = func(*engine.Projinfo) error {
 			return nil
 		}
+	case integration.GoRuntime:
+		prepareProject = prepareGoProject
 	default:
 		prepareProject = nil // use default logic
 	}
 	return prepareProject
+}
+
+// Resolves the sdk/v3 master branch to a concrete pseudo-version once per
+// test process. Resolving the branch in every test hits the module proxy
+// ~20 times in parallel and intermittently fails on fresh, uncached master
+// commits; `go get` then silently falls back to the repo root module and
+// the install fails (see pulumi/templates#1166).
+var resolveDevSDKVersion = sync.OnceValues(func() (string, error) {
+	dir, err := os.MkdirTemp("", "sdk-version-resolve")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(dir)
+	goMod := "module resolve\n\ngo 1.21\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o600); err != nil {
+		return "", err
+	}
+
+	var lastErr error
+	for attempt := range 5 {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * 10 * time.Second)
+		}
+		cmd := exec.Command("go", "list", "-m", "-f", "{{.Version}}", "github.com/pulumi/pulumi/sdk/v3@master")
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			lastErr = fmt.Errorf("resolving sdk/v3@master: %w: %s", err, out)
+			continue
+		}
+		return strings.TrimSpace(string(out)), nil
+	}
+	return "", lastErr
+})
+
+// Replaces the default Go project preparation from ProgramTest, which runs
+// `go get -u .../sdk/v3@master` per test. Installs the dev SDK at the
+// pinned version resolved by resolveDevSDKVersion instead.
+func prepareGoProject(projinfo *engine.Projinfo) error {
+	cwd, _, err := projinfo.GetPwdMain()
+	if err != nil {
+		return err
+	}
+
+	version, err := resolveDevSDKVersion()
+	if err != nil {
+		return err
+	}
+
+	steps := [][]string{
+		{"go", "get", "-u", "github.com/pulumi/pulumi/sdk/v3@" + version},
+		{"go", "mod", "tidy"},
+	}
+	for _, step := range steps {
+		cmd := exec.Command(step[0], step[1:]...)
+		cmd.Dir = cwd
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("%s: %w: %s", strings.Join(step, " "), err, out)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Try to resolve the Go module ahead of time.  Claude claims that concurrent attempts at downloading here can lead to module resolution problems, leading to test failures.  Since I don't have a better explanation, try to go with that and see if it helps.

Fixes https://github.com/pulumi/templates/issues/1166