### PR TITLE
Unpin oci-python and oci-typescript dependencies

### DIFF
--- a/oci-python/requirements.txt
+++ b/oci-python/requirements.txt
@@ -1,2 +1,2 @@
-pulumi==3.60.0
-pulumi-oci==0.13.0
+pulumi>=3.0.0,<4.0.0
+pulumi-oci>=4.0.0,<5.0.0

--- a/oci-typescript/package.json
+++ b/oci-typescript/package.json
@@ -6,7 +6,7 @@
         "typescript": "^5.0.0"
     },
     "dependencies": {
-        "@pulumi/oci": "0.13.0",
+        "@pulumi/oci": "^4.0.0",
         "@pulumi/pulumi": "^3.113.0"
     }
 }


### PR DESCRIPTION
Reported in community slack

`pulumi new oci-python` fails on Python 3.12:

```
  × Failed to build `grpcio==1.51.3`
  ╰─▶ ModuleNotFoundError: No module named 'pkg_resources'
  help: `grpcio` (v1.51.3) was included because ... depends on `pulumi` (v3.60.0)
```

`oci-python` is the only Python template with exact pins (`pulumi==3.60.0`, `pulumi-oci==0.13.0`). `pulumi` 3.60.0 requires `grpcio==1.51.3`, which ships no wheel for CPython 3.12 and can't build from source against setuptools >= 81.

This switches to ranges like the other templates, and moves `pulumi-oci` to the 4.x range that `oci-go` and `oci-java` already use. `oci-typescript` had the same exact `@pulumi/oci: 0.13.0` pin, so it gets the same treatment.

Verified locally: `pulumi install` now succeeds (resolves pulumi 3.259.0 / pulumi-oci 4.20.0), and `oci.identity.Compartment`, `oci.objectstorage.Bucket`, and `oci.objectstorage.get_namespace` all still exist in pulumi-oci 4.x, so `__main__.py` needs no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)