### PR TITLE
gcp-java: use an exclusive upper bound on the gcp version range

### DIFF
--- a/gcp-java/pom.xml
+++ b/gcp-java/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.pulumi</groupId>
             <artifactId>gcp</artifactId>
-            <version>[9.0.0,10.0]</version>
+            <version>[9.0.0,10.0)</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
The `com.pulumi:gcp` range in `gcp-java/pom.xml` closed with `]`. Maven treats that as inclusive, and `ComparableVersion` trims trailing zero segments so `10.0` and `10.0.0` compare equal, which means the range admitted `10.0.0`. Switching to `)` brings it in line with every other Java template in the repo, all of which already use an exclusive upper bound.

Part of pulumi/pulumi-gcp#3931
